### PR TITLE
Added experimental high cadence support #27

### DIFF
--- a/src/controller/ebike_app.c
+++ b/src/controller/ebike_app.c
@@ -353,9 +353,9 @@ static void communications_controller (void)
 
         case 3:
           configuration_variables.ui8_cruise_control = ui8_rx_buffer [7] & 1;
-          configuration_variables.ui8_motor_voltage_type = (ui8_rx_buffer [7] & 2) >> 1;
-          configuration_variables.ui8_motor_assistance_startup_without_pedal_rotation = (ui8_rx_buffer [7] & 4) >> 2;
-          configuration_variables.ui8_temperature_limit_feature_enabled = (ui8_rx_buffer [7] & 8) >> 3;
+          configuration_variables.ui8_motor_type = (ui8_rx_buffer [7] & 6) >> 1;
+          configuration_variables.ui8_motor_assistance_startup_without_pedal_rotation = (ui8_rx_buffer [7] & 8) >> 3;
+          configuration_variables.ui8_temperature_limit_feature_enabled = (ui8_rx_buffer [7] & 16) >> 4;
 
           configuration_variables.ui8_startup_motor_power_boost_state = ui8_rx_buffer [8] & 1;
           configuration_variables.ui8_startup_motor_power_boost_limit_to_max_power = (ui8_rx_buffer [8] & 2) >> 1;

--- a/src/controller/ebike_app.h
+++ b/src/controller/ebike_app.h
@@ -30,7 +30,7 @@ typedef struct _configuration_variables
   uint8_t ui8_offroad_mode;
   uint8_t ui8_wheel_max_speed;
   uint8_t ui8_pas_max_cadence;
-  uint8_t ui8_motor_voltage_type;
+  uint8_t ui8_motor_type;
   uint8_t ui8_motor_assistance_startup_without_pedal_rotation;
   uint8_t ui8_target_battery_max_power_div25;
   uint8_t ui8_cruise_control;

--- a/src/controller/eeprom.c
+++ b/src/controller/eeprom.c
@@ -102,8 +102,8 @@ static void eeprom_read_values_to_variables (void)
   p_configuration_variables->ui8_pas_max_cadence = FLASH_ReadByte (ADDRESS_PAS_MAX_CADENCE);
 
   ui8_temp = FLASH_ReadByte (ADDRESS_CONFIG_1);
-  p_configuration_variables->ui8_motor_voltage_type = ui8_temp & 1;
-  p_configuration_variables->ui8_motor_assistance_startup_without_pedal_rotation = (ui8_temp & 2) >> 1;
+  p_configuration_variables->ui8_motor_type = ui8_temp & 3;
+  p_configuration_variables->ui8_motor_assistance_startup_without_pedal_rotation = (ui8_temp & 4) >> 2;
 
   ui8_temp = FLASH_ReadByte (ADDRESS_OFFROAD_CONFIG);
   p_configuration_variables->ui8_offroad_feature_enabled = ui8_temp & 1;
@@ -139,8 +139,8 @@ static void variables_to_array (uint8_t *ui8_array)
   ui8_array [8] = (p_configuration_variables->ui16_wheel_perimeter >> 8) & 255;
   ui8_array [9] = p_configuration_variables->ui8_wheel_max_speed;
   ui8_array [10] = p_configuration_variables->ui8_pas_max_cadence;
-  ui8_array [11] = (p_configuration_variables->ui8_motor_voltage_type & 1) |
-                      ((p_configuration_variables->ui8_motor_assistance_startup_without_pedal_rotation & 1) << 1);
+  ui8_array [11] = (p_configuration_variables->ui8_motor_type & 3) |
+                      ((p_configuration_variables->ui8_motor_assistance_startup_without_pedal_rotation & 1) << 2);
   ui8_array [12] = (p_configuration_variables->ui8_offroad_feature_enabled & 1) |
                       ((p_configuration_variables->ui8_offroad_enabled_on_startup & 1) << 1) |
                         ((p_configuration_variables->ui8_offroad_power_limit_enabled & 1) << 2);

--- a/src/controller/main.h
+++ b/src/controller/main.h
@@ -28,7 +28,8 @@
 #define MOTOR_ROTOR_ANGLE_330   (233 + MOTOR_ROTOR_OFFSET_ANGLE)
 #define MOTOR_ROTOR_ANGLE_30    (20  + MOTOR_ROTOR_OFFSET_ANGLE)
 
-#define MOTOR_OVER_SPEED_ERPS 520 // motor max speed, protection max value | 30 points for the sinewave at max speed
+#define MOTOR_OVER_SPEED_ERPS               520 // motor max speed, protection max value | 30 points for the sinewave at max speed
+#define MOTOR_OVER_SPEED_ERPS_EXPERIMENTAL  700 // experimental max motor speed to allow a higher cadence
 
 #define WHEEL_SPEED_PI_CONTROLLER_KP_DIVIDEND	100
 #define WHEEL_SPEED_PI_CONTROLLER_KP_DIVISOR	4

--- a/src/display/KT-LCD3/eeprom.c
+++ b/src/display/KT-LCD3/eeprom.c
@@ -123,7 +123,7 @@ void eeprom_init_variables (void)
 //      (p_configuration_variables->ui16_battery_low_voltage_cut_off_x10 > 630) ||
 //      (p_configuration_variables->ui16_battery_low_voltage_cut_off_x10 < 160) ||
 //      (p_configuration_variables->ui8_cruise_control > 1) ||
-//      (p_configuration_variables->ui8_motor_voltage_type > 1) ||
+//      (p_configuration_variables->ui8_motor_type > 2) ||
 //      (p_configuration_variables->ui8_motor_temperature_min_value_to_limit < 124) ||
 //      (p_configuration_variables->ui8_motor_temperature_max_value_to_limit < 124) ||
 //      (p_configuration_variables->ui8_motor_assistance_startup_without_pedal_rotation > 1))
@@ -185,10 +185,10 @@ static void eeprom_read_values_to_variables (void)
   p_configuration_variables->ui8_pas_max_cadence = FLASH_ReadByte (ADDRESS_PAS_MAX_CADENCE);
 
   ui8_temp = FLASH_ReadByte (ADDRESS_CONFIG_0);
-  p_configuration_variables->ui8_motor_voltage_type = ui8_temp & 1;
-  p_configuration_variables->ui8_motor_assistance_startup_without_pedal_rotation = (ui8_temp & 2) >> 1;
-  p_configuration_variables->ui8_temperature_limit_feature_enabled = (ui8_temp & 4) >> 2;
-  p_configuration_variables->ui8_temperature_field_config = (ui8_temp & 24) >> 3;
+  p_configuration_variables->ui8_motor_type = ui8_temp & 3;
+  p_configuration_variables->ui8_motor_assistance_startup_without_pedal_rotation = (ui8_temp & 4) >> 2;
+  p_configuration_variables->ui8_temperature_limit_feature_enabled = (ui8_temp & 8) >> 3;
+  p_configuration_variables->ui8_temperature_field_config = (ui8_temp & 48) >> 4;
 
   p_configuration_variables->ui8_number_of_assist_levels = FLASH_ReadByte (ADDRESS_NUMBER_OF_ASSIST_LEVELS);
   for (ui8_index = 0; ui8_index < 9; ui8_index++)
@@ -273,10 +273,10 @@ static void variables_to_array (uint8_t *ui8_array)
   ui8_array [19] = p_configuration_variables->ui16_battery_low_voltage_cut_off_x10 & 255;
   ui8_array [20] = (p_configuration_variables->ui16_battery_low_voltage_cut_off_x10 >> 8) & 255;
   ui8_array [21] = p_configuration_variables->ui8_pas_max_cadence;
-  ui8_array [22] = (p_configuration_variables->ui8_motor_voltage_type & 1) |
-                      ((p_configuration_variables->ui8_motor_assistance_startup_without_pedal_rotation & 1) << 1) |
-                      ((p_configuration_variables->ui8_temperature_limit_feature_enabled & 1) << 2) |
-                      ((p_configuration_variables->ui8_temperature_field_config & 3) << 3);
+  ui8_array [22] = (p_configuration_variables->ui8_motor_type & 3) |
+                      ((p_configuration_variables->ui8_motor_assistance_startup_without_pedal_rotation & 1) << 2) |
+                      ((p_configuration_variables->ui8_temperature_limit_feature_enabled & 1) << 3) |
+                      ((p_configuration_variables->ui8_temperature_field_config & 3) << 4);
 
   for (ui8_index = 0; ui8_index < 9; ui8_index++)
   {

--- a/src/display/KT-LCD3/lcd.c
+++ b/src/display/KT-LCD3/lcd.c
@@ -1194,19 +1194,20 @@ void lcd_execute_menu_config_submenu_various (void)
       if (get_button_up_click_event ())
       {
         clear_button_up_click_event ();
-        configuration_variables.ui8_motor_voltage_type |= 1;
+        configuration_variables.ui8_motor_type++;
       }
 
       if (get_button_down_click_event ())
       {
         clear_button_down_click_event ();
-        configuration_variables.ui8_motor_voltage_type &= ~1;
+        configuration_variables.ui8_motor_type--;
       }
 
-      ui8_temp = ((configuration_variables.ui8_motor_voltage_type & 1) ? 1 : 0);
+      if (configuration_variables.ui8_motor_type > 2) { configuration_variables.ui8_motor_type = 2; }
+
       if (ui8_lcd_menu_flash_state)
       {
-        lcd_print (ui8_temp, ODOMETER_FIELD, 1);
+        lcd_print (configuration_variables.ui8_motor_type, ODOMETER_FIELD, 1);
       }
     break;
 

--- a/src/display/KT-LCD3/lcd.h
+++ b/src/display/KT-LCD3/lcd.h
@@ -57,7 +57,7 @@ typedef struct _configuration_variables
   uint16_t ui16_battery_low_voltage_cut_off_x10;
   uint16_t ui16_battery_voltage_reset_wh_counter_x10;
   uint16_t ui16_battery_pack_resistance_x1000;
-  uint8_t ui8_motor_voltage_type;
+  uint8_t ui8_motor_type;
   uint8_t ui8_motor_assistance_startup_without_pedal_rotation;
   uint8_t ui8_pas_max_cadence;
   uint8_t ui8_cruise_control;

--- a/src/display/KT-LCD3/main.h
+++ b/src/display/KT-LCD3/main.h
@@ -36,7 +36,7 @@
 #define DEFAULT_VALUE_BATTERY_LOW_VOLTAGE_CUT_OFF_X10_0             134 // 48v battery, LVC = 39.0 (3.0 * 13): (134 + (1 << 8))
 #define DEFAULT_VALUE_BATTERY_LOW_VOLTAGE_CUT_OFF_X10_1             1
 #define DEFAULT_VALUE_PAS_MAX_CADENCE                               110 // 110 RPM
-#define DEFAULT_VALUE_CONFIG_0                                      0 // ui8_motor_voltage_type = 0; ui8_motor_assistance_startup_config = 0
+#define DEFAULT_VALUE_CONFIG_0                                      0 // ui8_motor_type = 0; ui8_motor_assistance_startup_config = 0
 #define DEFAULT_VALUE_ASSIST_LEVEL_FACTOR_1                         16 // 400W
 #define DEFAULT_VALUE_ASSIST_LEVEL_FACTOR_2                         24
 #define DEFAULT_VALUE_ASSIST_LEVEL_FACTOR_3                         32

--- a/src/display/KT-LCD3/uart.c
+++ b/src/display/KT-LCD3/uart.c
@@ -235,9 +235,9 @@ void clock_uart_data (void)
           // bit 1: motor voltage type: 36V or 48V
           // bit 2: MOTOR_ASSISTANCE_CAN_START_WITHOUT_PEDAL_ROTATION
           ui8_tx_buffer[7] = ((p_configuration_variables->ui8_cruise_control & 1) |
-                             ((p_configuration_variables->ui8_motor_voltage_type & 1) << 1) |
-                              ((p_configuration_variables->ui8_motor_assistance_startup_without_pedal_rotation & 1) << 2) |
-                              ((p_configuration_variables->ui8_temperature_limit_feature_enabled & 1) << 3));
+                             ((p_configuration_variables->ui8_motor_type & 3) << 1) |
+                              ((p_configuration_variables->ui8_motor_assistance_startup_without_pedal_rotation & 1) << 3) |
+                              ((p_configuration_variables->ui8_temperature_limit_feature_enabled & 1) << 4));
           ui8_tx_buffer[8] = p_configuration_variables->ui8_startup_motor_power_boost_state;
         break;
 


### PR DESCRIPTION
No separate menu item needed just another motor configuration. The motor type options available now:

- 0 -> 48V motor
- 1 -> 36V motor
- 2 -> High cadence motor profile (probably suitable for 36V motors only and also only tested with a 36V motor)

The motor type should be configured in configuration menu 8.0. (default 48V/0)

The cadence isn't locked to 130 for this motor type because I found that 110-120 also works well and probably even scales better! It's up to the user because they can increase the cadence limit in configuration menu 8.2 (default 110). Otherwise, these settings would also collide with each other.