### PR TITLE
Motor minimal assist support

### DIFF
--- a/src/controller/ebike_app.c
+++ b/src/controller/ebike_app.c
@@ -151,10 +151,10 @@ static void ebike_control_motor (void)
   uint8_t ui8_startup_enable;
   uint8_t ui8_boost_enabled_and_applied = 0;
   uint8_t ui8_tmp_max_speed;
-  uini8_t ui8_human_cadence = 0;
+  uint8_t ui8_human_cadence = 0;
   uint8_t ui8_human_min_cadence = 0;
-  uini8_t ui8_human_torque = 0;
-  uini8_t ui8_human_min_torque = 0;
+  uint8_t ui8_human_torque = 0;
+  uint8_t ui8_human_min_torque = 0;
 
   uint16_t ui16_battery_voltage_filtered = calc_filtered_battery_voltage ();
 

--- a/src/controller/ebike_app.c
+++ b/src/controller/ebike_app.c
@@ -256,6 +256,15 @@ static void ebike_control_motor (void)
     }
   }
 
+  /*
+   * Add a minimal motor workload by setting a min current value
+   */
+  if (wheel_speed > 0)
+  {
+	  ui8_adc_battery_target_current = ui8_adc_battery_target_current > MIN_BATTERY_CURRENT ?
+			  ui8_adc_battery_target_current : MIN_BATTERY_CURRENT;
+  }
+
   /* Limit current if motor temperature too high and this feature is enabled by the user */
   if (configuration_variables.ui8_temperature_limit_feature_enabled)
   {

--- a/src/controller/ebike_app.c
+++ b/src/controller/ebike_app.c
@@ -261,8 +261,7 @@ static void ebike_control_motor (void)
    */
   if (wheel_speed > 0)
   {
-	  ui8_adc_battery_target_current = ui8_adc_battery_target_current > MIN_BATTERY_CURRENT ?
-			  ui8_adc_battery_target_current : MIN_BATTERY_CURRENT;
+	  ui8_adc_battery_target_current += MIN_BATTERY_CURRENT;
   }
 
   /* Limit current if motor temperature too high and this feature is enabled by the user */

--- a/src/controller/ebike_app.c
+++ b/src/controller/ebike_app.c
@@ -209,12 +209,12 @@ static void ebike_control_motor (void)
   if (!ui8_boost_enabled_and_applied)
   {
     /*
-     * In case of wheel speed > 0
+     * In case of measured cadence > 0
      * 	Human cadence has a minimum value of MIN_CADENCE_RPM.
      * 	Human torque has minimum MIN_TORQUE_UNITS(32 maximum).
-     * If stopped use old behavior.
+     * If stopped or pedal stop use old behavior.
      */
-    if (ui16_wheel_speed_x10 > 0 && ui8_tmp_pas_cadence_rpm > 0)
+    if (ui8_tmp_pas_cadence_rpm > 0)
     {
     	/*
     	 * Cadence

--- a/src/controller/ebike_app.c
+++ b/src/controller/ebike_app.c
@@ -261,7 +261,7 @@ static void ebike_control_motor (void)
    */
   if (ui16_wheel_speed_x10 > 0)
   {
-	  ui8_adc_battery_target_current += MIN_BATTERY_CURRENT;
+	  ui8_adc_battery_target_current += MIN_ADC_BATTERY_CURRENT;
   }
 
   /* Limit current if motor temperature too high and this feature is enabled by the user */

--- a/src/controller/ebike_app.c
+++ b/src/controller/ebike_app.c
@@ -211,10 +211,10 @@ static void ebike_control_motor (void)
     /*
      * In case of wheel speed > 0
      * 	Human cadence has a minimum value of MIN_CADENCE_RPM.
-     * 	Human torque has minimum MIN_TORQUE_UNITS(32 * ADC_TORQUE_UNITS = 256 TORQUE_UNITS so 1/8).
+     * 	Human torque has minimum MIN_TORQUE_UNITS(32 maximum).
      * If stopped use old behavior.
      */
-    if (ui16_wheel_speed_x10 > 0)
+    if (ui16_wheel_speed_x10 > 0 && ui8_tmp_pas_cadence_rpm > 0)
     {
     	/*
     	 * Cadence

--- a/src/controller/ebike_app.c
+++ b/src/controller/ebike_app.c
@@ -259,7 +259,7 @@ static void ebike_control_motor (void)
   /*
    * Add a minimal motor workload by setting a min current value
    */
-  if (wheel_speed > 0)
+  if (ui16_wheel_speed_x10 > 0)
   {
 	  ui8_adc_battery_target_current += MIN_BATTERY_CURRENT;
   }

--- a/src/controller/ebike_app.h
+++ b/src/controller/ebike_app.h
@@ -18,6 +18,9 @@
 #define EBIKE_APP_STATE_MOTOR_COOL      3
 #define EBIKE_APP_STATE_MOTOR_RUNNING   4
 
+#define MIN_ADC_TORQUE_UNITS            2
+#define MIN_CADENCE_RPM                25
+
 typedef struct _configuration_variables
 {
   uint8_t ui8_power_regular_state_div25;

--- a/src/controller/ebike_app.h
+++ b/src/controller/ebike_app.h
@@ -17,6 +17,7 @@
 #define EBIKE_APP_STATE_MOTOR_STARTUP   2
 #define EBIKE_APP_STATE_MOTOR_COOL      3
 #define EBIKE_APP_STATE_MOTOR_RUNNING   4
+#define MIN_BATTERY_CURRENT             0.5
 
 typedef struct _configuration_variables
 {

--- a/src/controller/ebike_app.h
+++ b/src/controller/ebike_app.h
@@ -19,8 +19,8 @@
 #define EBIKE_APP_STATE_MOTOR_RUNNING   4
 #define MIN_ADC_BATTERY_CURRENT         1 //1 unit = 0.625 amp
 
-#define MIN_ADC_TORQUE_UNITS            4
-#define MIN_CADENCE_RPM                15
+#define MIN_ADC_TORQUE_UNITS            5
+#define MIN_CADENCE_RPM                10
 
 typedef struct _configuration_variables
 {

--- a/src/controller/ebike_app.h
+++ b/src/controller/ebike_app.h
@@ -19,8 +19,8 @@
 #define EBIKE_APP_STATE_MOTOR_RUNNING   4
 #define MIN_ADC_BATTERY_CURRENT         1 //1 unit = 0.625 amp
 
-#define MIN_ADC_TORQUE_UNITS            8
-#define MIN_CADENCE_RPM                25
+#define MIN_ADC_TORQUE_UNITS            4
+#define MIN_CADENCE_RPM                15
 
 typedef struct _configuration_variables
 {

--- a/src/controller/ebike_app.h
+++ b/src/controller/ebike_app.h
@@ -17,7 +17,7 @@
 #define EBIKE_APP_STATE_MOTOR_STARTUP   2
 #define EBIKE_APP_STATE_MOTOR_COOL      3
 #define EBIKE_APP_STATE_MOTOR_RUNNING   4
-#define MIN_BATTERY_CURRENT             0.5
+#define MIN_BATTERY_CURRENT             1 //1 unit = 0.625 amp
 
 typedef struct _configuration_variables
 {

--- a/src/controller/ebike_app.h
+++ b/src/controller/ebike_app.h
@@ -18,7 +18,7 @@
 #define EBIKE_APP_STATE_MOTOR_COOL      3
 #define EBIKE_APP_STATE_MOTOR_RUNNING   4
 
-#define MIN_ADC_TORQUE_UNITS            2
+#define MIN_ADC_TORQUE_UNITS            8
 #define MIN_CADENCE_RPM                25
 
 typedef struct _configuration_variables

--- a/src/controller/ebike_app.h
+++ b/src/controller/ebike_app.h
@@ -17,7 +17,7 @@
 #define EBIKE_APP_STATE_MOTOR_STARTUP   2
 #define EBIKE_APP_STATE_MOTOR_COOL      3
 #define EBIKE_APP_STATE_MOTOR_RUNNING   4
-#define MIN_BATTERY_CURRENT             1 //1 unit = 0.625 amp
+#define MIN_ADC_BATTERY_CURRENT         1 //1 unit = 0.625 amp
 
 typedef struct _configuration_variables
 {


### PR DESCRIPTION
### Problem observed
While riding there is a noticeable delay between the motor response and the pedal action. One explication is that the motor needs time to get from 0 to requested speed. This can be fixed (at least partial) by keeping a minimal load on the motor.

### Solution
Idea is to add a minimal torque sensor load and min cadence load on the motor only while wheel is moving. The rest of the behavior should remain unchanged, only the power calculation should be impacted by the changes . Ideally these parameters should be added to the menu. (need some support for that :))

The way the human power is calculated is **P = Cad * Torque** so minimal power is influenced by both.
The power is calculated in procents so cadence and torque are always between 0-255.
This is done by using mapping functions that translate one interval into 0-255. Because now there are minimal values the mapping starts from min value instead of 0, the input interval is smaller making the function more responsive.
Eg: Cadence function: (0-100) -> (0-255)
In case min cadence is 50 the function becomes (50-100)->(0-255) so for each unit of cadence you get 2X more cadence in procents. So the cadence acceleration is 2X.

