### PR TITLE
Minimal motor current

### DIFF
--- a/src/controller/ebike_app.c
+++ b/src/controller/ebike_app.c
@@ -256,6 +256,15 @@ static void ebike_control_motor (void)
     }
   }
 
+  /*
+   * Add a minimal motor workload by setting a min current value
+   */
+  if (wheel_speed > 0)
+  {
+	  ui8_adc_battery_target_current = ui8_adc_battery_target_current > MIN_BATTERY_CURRENT ?
+			  ui8_adc_battery_target_current : MIN_BATTERY_CURRENT;
+  }
+
   /* Limit current if motor temperature too high and this feature is enabled by the user */
   if (configuration_variables.ui8_temperature_limit_feature_enabled)
   {

--- a/src/controller/ebike_app.c
+++ b/src/controller/ebike_app.c
@@ -261,8 +261,7 @@ static void ebike_control_motor (void)
    */
   if (wheel_speed > 0)
   {
-	  ui8_adc_battery_target_current = ui8_adc_battery_target_current > MIN_BATTERY_CURRENT ?
-			  ui8_adc_battery_target_current : MIN_BATTERY_CURRENT;
+	  ui8_adc_battery_target_current += MIN_BATTERY_CURRENT;
   }
 
   /* Limit current if motor temperature too high and this feature is enabled by the user */

--- a/src/controller/ebike_app.c
+++ b/src/controller/ebike_app.c
@@ -261,7 +261,7 @@ static void ebike_control_motor (void)
    */
   if (ui16_wheel_speed_x10 > 0)
   {
-	  ui8_adc_battery_target_current += MIN_BATTERY_CURRENT;
+	  ui8_adc_battery_target_current += MIN_ADC_BATTERY_CURRENT;
   }
 
   /* Limit current if motor temperature too high and this feature is enabled by the user */

--- a/src/controller/ebike_app.c
+++ b/src/controller/ebike_app.c
@@ -259,7 +259,7 @@ static void ebike_control_motor (void)
   /*
    * Add a minimal motor workload by setting a min current value
    */
-  if (wheel_speed > 0)
+  if (ui16_wheel_speed_x10 > 0)
   {
 	  ui8_adc_battery_target_current += MIN_BATTERY_CURRENT;
   }

--- a/src/controller/ebike_app.h
+++ b/src/controller/ebike_app.h
@@ -17,6 +17,7 @@
 #define EBIKE_APP_STATE_MOTOR_STARTUP   2
 #define EBIKE_APP_STATE_MOTOR_COOL      3
 #define EBIKE_APP_STATE_MOTOR_RUNNING   4
+#define MIN_BATTERY_CURRENT             0.5
 
 typedef struct _configuration_variables
 {

--- a/src/controller/ebike_app.h
+++ b/src/controller/ebike_app.h
@@ -17,7 +17,7 @@
 #define EBIKE_APP_STATE_MOTOR_STARTUP   2
 #define EBIKE_APP_STATE_MOTOR_COOL      3
 #define EBIKE_APP_STATE_MOTOR_RUNNING   4
-#define MIN_BATTERY_CURRENT             0.5
+#define MIN_BATTERY_CURRENT             1 //1 unit = 0.625 amp
 
 typedef struct _configuration_variables
 {

--- a/src/controller/ebike_app.h
+++ b/src/controller/ebike_app.h
@@ -17,7 +17,7 @@
 #define EBIKE_APP_STATE_MOTOR_STARTUP   2
 #define EBIKE_APP_STATE_MOTOR_COOL      3
 #define EBIKE_APP_STATE_MOTOR_RUNNING   4
-#define MIN_BATTERY_CURRENT             1 //1 unit = 0.625 amp
+#define MIN_ADC_BATTERY_CURRENT         1 //1 unit = 0.625 amp
 
 typedef struct _configuration_variables
 {


### PR DESCRIPTION
> I would add a min value of motor current, near the final sequence of motor current that is calculated on ebike_control_motor(). The min motor current should be a fixed value that do not depends of pedal torque and cadence.
> 
> casainho

I added only 1 unit. should be enough.
