### PR TITLE
Bug fixes and improvments after 0.17 merge

### DIFF
--- a/src/display/KT-LCD3/eeprom.c
+++ b/src/display/KT-LCD3/eeprom.c
@@ -87,7 +87,8 @@ static uint8_t array_default_values [EEPROM_BYTES_STORED] = {
     DEFAULT_VALUE_ODOMETER_SUB_FIELD_STATE_3,
     DEFAULT_VALUE_ODOMETER_SUB_FIELD_STATE_4,
     DEFAULT_VALUE_ODOMETER_SUB_FIELD_STATE_5,
-    DEFAULT_VALUE_ODOMETER_SUB_FIELD_STATE_6
+    DEFAULT_VALUE_ODOMETER_SUB_FIELD_STATE_6,
+    DEFAULT_VALUE_WHEEL_MAX_SPEED_IMPERIAL
   };
 
 static void eeprom_write_array (uint8_t *p_array_data, uint8_t ui8_len);
@@ -162,6 +163,7 @@ static void eeprom_read_values_to_variables (void)
   p_configuration_variables->ui16_wheel_perimeter = ui16_temp;
 
   p_configuration_variables->ui8_wheel_max_speed = FLASH_ReadByte (ADDRESS_MAX_WHEEL_SPEED);
+  p_configuration_variables->ui8_wheel_max_speed_imperial = FLASH_ReadByte (ADDRESS_MAX_WHEEL_SPEED_IMPERIAL);
   p_configuration_variables->ui8_units_type = FLASH_ReadByte (ADDRESS_UNITS_TYPE);
 
   ui32_temp = FLASH_ReadByte (ADDRESS_HW_X10_OFFSET_0);
@@ -361,6 +363,9 @@ static void variables_to_array (uint8_t *ui8_array)
   ui8_array [69] = p_configuration_variables->ui8_odometer_sub_field_state_4;
   ui8_array [70] = p_configuration_variables->ui8_odometer_sub_field_state_5;
   ui8_array [71] = p_configuration_variables->ui8_odometer_sub_field_state_6;
+  
+  // write max wheel speed in imperial units
+  ui8_array [72] = p_configuration_variables->ui8_wheel_max_speed_imperial;
 }
 
 static void eeprom_write_array (uint8_t *p_array, uint8_t ui8_len)

--- a/src/display/KT-LCD3/eeprom.h
+++ b/src/display/KT-LCD3/eeprom.h
@@ -86,7 +86,8 @@
 #define ADRESS_ODOMETER_SUB_FIELD_STATE_4                                   69 + EEPROM_BASE_ADDRESS
 #define ADRESS_ODOMETER_SUB_FIELD_STATE_5                                   70 + EEPROM_BASE_ADDRESS
 #define ADRESS_ODOMETER_SUB_FIELD_STATE_6                                   71 + EEPROM_BASE_ADDRESS
-#define EEPROM_BYTES_STORED                                                 72
+#define ADDRESS_MAX_WHEEL_SPEED_IMPERIAL                                    72 + EEPROM_BASE_ADDRESS
+#define EEPROM_BYTES_STORED                                                 73
 
 void eeprom_init (void);
 void eeprom_init_variables (void);

--- a/src/display/KT-LCD3/lcd.c
+++ b/src/display/KT-LCD3/lcd.c
@@ -550,7 +550,8 @@ void lcd_execute_menu_config_submenu_wheel_config(void)
 void lcd_execute_menu_config_submenu_battery (void)
 {
   var_number_t lcd_var_number;
-
+  
+  // advance on submenus on button_onoff_click_event
   advance_on_submenu(&ui8_lcd_menu_config_submenu_state, 5);
 
   switch (ui8_lcd_menu_config_submenu_state)
@@ -617,7 +618,8 @@ void lcd_execute_menu_config_submenu_battery_soc (void)
 {
   uint8_t ui8_temp;
   var_number_t lcd_var_number;
-
+  
+  // advance on submenus on button_onoff_click_event
   advance_on_submenu (&ui8_lcd_menu_config_submenu_state, 5);
 
   switch (ui8_lcd_menu_config_submenu_state)
@@ -654,7 +656,7 @@ void lcd_execute_menu_config_submenu_battery_soc (void)
       else { configuration_variables.ui8_show_numeric_battery_soc &= ~2; }
     break;
 
-    // battery_voltage_reset_wh_counter
+    // menu to set battery_voltage_reset_wh_counter
     case 2:
       lcd_var_number.p_var_number = &configuration_variables.ui16_battery_voltage_reset_wh_counter_x10;
       lcd_var_number.ui8_size = 16;
@@ -678,7 +680,7 @@ void lcd_execute_menu_config_submenu_battery_soc (void)
       lcd_configurations_print_number(&lcd_var_number);
     break;
 
-    // menu to set current watts hour value
+    // menu to set current watt hour value
     case 4:
       // on the very first time, use current value of ui32_wh_x10
       if (ui8_config_wh_x10_offset)
@@ -686,6 +688,7 @@ void lcd_execute_menu_config_submenu_battery_soc (void)
         ui8_config_wh_x10_offset = 0;
         configuration_variables.ui32_wh_x10_offset = ui32_wh_x10;
       }
+      
       // keep reseting this values
       ui32_wh_sum_x5 = 0;
       ui32_wh_sum_counter = 0;
@@ -708,8 +711,9 @@ void lcd_execute_menu_config_submenu_battery_soc (void)
 void lcd_execute_menu_config_submenu_assist_level (void)
 {
   var_number_t lcd_var_number;
-
-  advance_on_submenu (&ui8_lcd_menu_config_submenu_state, (configuration_variables.ui8_number_of_assist_levels + 1));
+  
+  // advance on submenus on button_onoff_click_event
+  advance_on_submenu (&ui8_lcd_menu_config_submenu_state, (configuration_variables.ui8_number_of_assist_levels + 1));                   //CHECK IF OVERFLOW
 
   // number of assist levels: 0 to 9
   if (ui8_lcd_menu_config_submenu_state == 0)
@@ -743,7 +747,8 @@ void lcd_execute_menu_config_submenu_motor_startup_power_boost (void)
 {
   var_number_t lcd_var_number;
   uint8_t ui8_temp;
-
+  
+  // advance on submenus on button_onoff_click_event
   advance_on_submenu (&ui8_lcd_menu_config_submenu_state, (configuration_variables.ui8_number_of_assist_levels + 5));
 
   // feature enable or disable
@@ -833,7 +838,8 @@ void lcd_execute_menu_config_submenu_motor_startup_power_boost (void)
 void lcd_execute_menu_config_submenu_motor_temperature (void)
 {
   var_number_t lcd_var_number;
-
+  
+  // advance on submenus on button_onoff_click_event
   advance_on_submenu (&ui8_lcd_menu_config_submenu_state, 3);
 
   switch (ui8_lcd_menu_config_submenu_state)
@@ -882,7 +888,8 @@ void lcd_execute_menu_config_submenu_lcd (void)
 {
   var_number_t lcd_var_number;
   uint8_t ui8_temp;
-
+  
+  // advance on submenus on button_onoff_click_event
   advance_on_submenu (&ui8_lcd_menu_config_submenu_state, 4);
 
   switch (ui8_lcd_menu_config_submenu_state)
@@ -940,9 +947,10 @@ void lcd_execute_menu_config_submenu_lcd (void)
 
       if (ui8_reset_to_defaults_counter > 9)
       {
+        // erase saved EEPROM values (all values will be set to defaults)
         eeprom_erase_key_value ();
 
-        // Turn off LCD, when the user turns it on again it will rewrite the defaults
+        // Turn off LCD
         lcd_power_off (0);
       }
     break;
@@ -955,7 +963,8 @@ void lcd_execute_menu_config_submenu_offroad_mode (void)
 {
   var_number_t lcd_var_number;
   uint16_t ui16_temp;
-
+  
+  // advance on submenus on button_onoff_click_event
   advance_on_submenu (&ui8_lcd_menu_config_submenu_state, 5);
 
   switch (ui8_lcd_menu_config_submenu_state)
@@ -1029,7 +1038,8 @@ void lcd_execute_menu_config_submenu_various (void)
 {
   var_number_t lcd_var_number;
   uint32_t ui32_odometer_x10;
-
+  
+  // advance on submenus on button_onoff_click_event
   advance_on_submenu (&ui8_lcd_menu_config_submenu_state, 3);
 
   switch (ui8_lcd_menu_config_submenu_state)
@@ -1061,6 +1071,7 @@ void lcd_execute_menu_config_submenu_various (void)
     // set odometer
     case 2:
       ui32_odometer_x10 = configuration_variables.ui32_odometer_x10;
+      
       if (configuration_variables.ui8_units_type)
       {
         // imperial
@@ -1097,6 +1108,7 @@ void lcd_execute_menu_config_submenu_various (void)
 
 void lcd_execute_menu_config_submenu_technical (void)
 {
+  // advance on submenus on button_onoff_click_event
   advance_on_submenu (&ui8_lcd_menu_config_submenu_state, 9);
 
   switch (ui8_lcd_menu_config_submenu_state)
@@ -1286,11 +1298,11 @@ void battery_soc(void)
   switch (ui8_battery_state_of_charge)
   {
     case 0:
-    // empty, so flash the empty battery symbol
-    if (ui8_lcd_menu_flash_state)
-    {
-      ui8_lcd_frame_buffer[23] |= 16;
-    }
+      // empty, so flash the empty battery symbol
+      if (ui8_lcd_menu_flash_state)
+      {
+        ui8_lcd_frame_buffer[23] |= 16;
+      }
     break;
 
     case 1:
@@ -1366,7 +1378,7 @@ void lights_state (void)
     else
     {
       ui8_lights_state = 0;
-      lcd_lights_symbol = 0;
+      lcd_lights_symbol = 0;                                                                                                    // Make lcd_enable_lights_symbol ()
       motor_controller_data.ui8_lights = 0;
     }
   }
@@ -2414,13 +2426,13 @@ void low_pass_filter_battery_voltage_current_power (void)
   ui16_battery_power_filtered_x50 = ui16_battery_current_filtered_x5 * ui16_battery_voltage_filtered_x10;
   ui16_battery_power_filtered = ui16_battery_power_filtered_x50 / 50;
 
-  // loose resolution under 200W
+  // loose resolution under 200 W
   if (ui16_battery_power_filtered < 200)
   {
     ui16_battery_power_filtered /= 10;
     ui16_battery_power_filtered *= 10;
   }
-  // loose resolution under 400W
+  // loose resolution under 400 W
   else if (ui16_battery_power_filtered < 400)
   {
     ui16_battery_power_filtered /= 20;
@@ -2793,7 +2805,6 @@ void lcd_configurations_print_number(var_number_t* p_lcd_var_number)
   }
 
   // if LONG CLICK, keep track of long click so variable is increased automatically 10x every second
-  //
   if(buttons_get_up_long_click_event() ||
       buttons_get_down_long_click_event())
   {

--- a/src/display/KT-LCD3/lcd.c
+++ b/src/display/KT-LCD3/lcd.c
@@ -451,7 +451,7 @@ void lcd_execute_menu_config_submenu_wheel_config(void)
   // advance on submenus on button_onoff_click_event
   advance_on_submenu(&ui8_lcd_menu_config_submenu_state, 3);
   
-  // if user has choosen imperial units
+  // if user has chosen imperial units
   if (configuration_variables.ui8_units_type)
   {
     // convert max wheel speed in imperial units to metric units and save to ui8_wheel_max_speed

--- a/src/display/KT-LCD3/lcd.c
+++ b/src/display/KT-LCD3/lcd.c
@@ -460,9 +460,39 @@ void lcd_execute_menu_config_submenu_wheel_config(void)
   
   switch(ui8_lcd_menu_config_submenu_state)
   {
-    // menu to choose max wheel speed
+    // menu to choose units type
     case 0:
+      
+      ui8_units_type = configuration_variables.ui8_units_type;
+      lcd_var_number.p_var_number = &ui8_units_type;
+      lcd_var_number.ui8_size = 8;
+      lcd_var_number.ui8_decimal_digit = 0;
+      lcd_var_number.ui32_max_value = 1;
+      lcd_var_number.ui32_min_value = 0;
+      lcd_var_number.ui32_increment_step = 1;
+      lcd_var_number.ui8_odometer_field = ODOMETER_FIELD;
+      lcd_configurations_print_number(&lcd_var_number);
+      // clear previous number written on ODOMETER_FIELD
+      ui8_lcd_frame_buffer[ui8_lcd_field_offset[ODOMETER_FIELD] - 1] &= NUMBERS_MASK;
+
+      if(ui8_units_type)
+      {
+        configuration_variables.ui8_units_type |= 1;
+        lcd_enable_mil_symbol (1);
+        lcd_enable_mph_symbol(1);
+      }
+      else
+      {
+        configuration_variables.ui8_units_type &= ~1;
+        lcd_enable_km_symbol (1);
+        lcd_enable_kmh_symbol(1);
+      }
+      
+    break;
     
+    // menu to choose max wheel speed
+    case 1:
+      
       // display max wheel speed in either imperial or metric units
       if (configuration_variables.ui8_units_type)
       {
@@ -492,10 +522,12 @@ void lcd_execute_menu_config_submenu_wheel_config(void)
         
         lcd_enable_kmh_symbol (1);
       }
+      
     break;
-
+    
     // menu to choose wheel perimeter in millimeters
-    case 1:
+    case 2:
+    
       lcd_var_number.p_var_number = &configuration_variables.ui16_wheel_perimeter;
       lcd_var_number.ui8_size = 16;
       lcd_var_number.ui8_decimal_digit = 0;
@@ -504,35 +536,7 @@ void lcd_execute_menu_config_submenu_wheel_config(void)
       lcd_var_number.ui32_increment_step = 1;
       lcd_var_number.ui8_odometer_field = ODOMETER_FIELD;
       lcd_configurations_print_number(&lcd_var_number);
-    break;
-
-    // menu to choose units type
-    case 2:
-      ui8_units_type = configuration_variables.ui8_units_type;
-      lcd_var_number.p_var_number = &ui8_units_type;
-      lcd_var_number.ui8_size = 8;
-      lcd_var_number.ui8_decimal_digit = 0;
-      lcd_var_number.ui32_max_value = 1;
-      lcd_var_number.ui32_min_value = 0;
-      lcd_var_number.ui32_increment_step = 1;
-      lcd_var_number.ui8_odometer_field = ODOMETER_FIELD;
-      lcd_configurations_print_number(&lcd_var_number);
-      // clear previous number written on ODOMETER_FIELD
-      ui8_lcd_frame_buffer[ui8_lcd_field_offset[ODOMETER_FIELD] - 1] &= NUMBERS_MASK;
-
-      if(ui8_units_type)
-      {
-        configuration_variables.ui8_units_type |= 1;
-        lcd_enable_mil_symbol (1);
-        lcd_enable_mph_symbol(1);
-      }
-      else
-      {
-        configuration_variables.ui8_units_type &= ~1;
-        lcd_enable_km_symbol (1);
-        lcd_enable_kmh_symbol(1);
-      }
-      
+    
     break;
   }
 }

--- a/src/display/KT-LCD3/lcd.c
+++ b/src/display/KT-LCD3/lcd.c
@@ -533,11 +533,13 @@ void lcd_execute_menu_config_submenu_wheel_config(void)
       if(ui8_units_type)
       {
         configuration_variables.ui8_units_type |= 1;
+        lcd_enable_mil_symbol (1);
         lcd_enable_mph_symbol(1);
       }
       else
       {
         configuration_variables.ui8_units_type &= ~1;
+        lcd_enable_km_symbol (1);
         lcd_enable_kmh_symbol(1);
       }
       

--- a/src/display/KT-LCD3/lcd.c
+++ b/src/display/KT-LCD3/lcd.c
@@ -707,7 +707,7 @@ void lcd_execute_menu_config_submenu_assist_level (void)
   var_number_t lcd_var_number;
   
   // advance on submenus on button_onoff_click_event
-  advance_on_submenu (&ui8_lcd_menu_config_submenu_state, (configuration_variables.ui8_number_of_assist_levels + 1));                   //CHECK IF OVERFLOW
+  advance_on_submenu (&ui8_lcd_menu_config_submenu_state, (configuration_variables.ui8_number_of_assist_levels + 1));
 
   // number of assist levels: 0 to 9
   if (ui8_lcd_menu_config_submenu_state == 0)

--- a/src/display/KT-LCD3/lcd.c
+++ b/src/display/KT-LCD3/lcd.c
@@ -447,8 +447,7 @@ void lcd_execute_menu_config_submenu_wheel_config(void)
 {
   var_number_t lcd_var_number;
   uint8_t ui8_units_type;
-  uint8_t ui8_wheel_max_speed;
-  uint16_t ui16_wheel_perimeter;
+  uint8_t ui8_temp;
 
   // advance on submenus on button_onoff_click_event
   advance_on_submenu(&ui8_lcd_menu_config_submenu_state, 3);
@@ -457,46 +456,45 @@ void lcd_execute_menu_config_submenu_wheel_config(void)
   {
     // menu to choose max wheel speed
     case 0:
-      ui8_wheel_max_speed = configuration_variables.ui8_wheel_max_speed;
+      
+      // display max wheel speed in either imperial or metric units
       if (configuration_variables.ui8_units_type)
       {
         // imperial
-        ui8_wheel_max_speed = (uint16_t) (((float) ui8_wheel_max_speed) / 1.6);
-      }
+        ui8_temp = configuration_variables.ui8_wheel_max_speed;
+        ui8_temp = (uint8_t) (((float) ui8_temp) / 1.6);       
 
-      lcd_var_number.p_var_number = &ui8_wheel_max_speed;
-      lcd_var_number.ui8_size = 8;
-      lcd_var_number.ui8_decimal_digit = 0;
-      lcd_var_number.ui32_max_value = 255;
-      lcd_var_number.ui32_min_value = 0;
-      lcd_var_number.ui32_increment_step = 1;
-      lcd_var_number.ui8_odometer_field = WHEEL_SPEED_FIELD;
-      lcd_configurations_print_number(&lcd_var_number);
-
-      if (configuration_variables.ui8_units_type)
-      {
-        // imperial
-        configuration_variables.ui8_wheel_max_speed = (uint16_t) (((float) ui8_wheel_max_speed) * 1.6);
+        lcd_var_number.p_var_number = &ui8_temp;
+        lcd_var_number.ui8_size = 8;
+        lcd_var_number.ui8_decimal_digit = 1;
+        lcd_var_number.ui32_max_value = 255;
+        lcd_var_number.ui32_min_value = 0;
+        lcd_var_number.ui32_increment_step = 1;
+        lcd_var_number.ui8_odometer_field = WHEEL_SPEED_FIELD;
+        lcd_configurations_print_number(&lcd_var_number);
+        
+        configuration_variables.ui8_wheel_max_speed = (uint8_t) (((float) ui8_temp) * 1.6);
         lcd_enable_mph_symbol (1);
       }
       else
       {
-        configuration_variables.ui8_wheel_max_speed = ui8_wheel_max_speed;
+        // metric  
+        lcd_var_number.p_var_number = &configuration_variables.ui8_wheel_max_speed;
+        lcd_var_number.ui8_size = 8;
+        lcd_var_number.ui8_decimal_digit = 0;
+        lcd_var_number.ui32_max_value = 255;
+        lcd_var_number.ui32_min_value = 0;
+        lcd_var_number.ui32_increment_step = 1;
+        lcd_var_number.ui8_odometer_field = WHEEL_SPEED_FIELD;        
+        lcd_configurations_print_number(&lcd_var_number);
+        
         lcd_enable_kmh_symbol (1);
       }
     break;
 
-    // menu to choose wheel perimeter
-    // TODO: fix so the mph limit increments and decrements nicely
+    // menu to choose wheel perimeter in millimeters
     case 1:
-      ui16_wheel_perimeter = configuration_variables.ui16_wheel_perimeter;
-      if (configuration_variables.ui8_units_type)
-      {
-        // imperial
-        ui16_wheel_perimeter = (uint16_t) (((float) ui16_wheel_perimeter) / 1.6);
-      }
-
-      lcd_var_number.p_var_number = &ui16_wheel_perimeter;
+      lcd_var_number.p_var_number = &configuration_variables.ui16_wheel_perimeter;
       lcd_var_number.ui8_size = 16;
       lcd_var_number.ui8_decimal_digit = 0;
       lcd_var_number.ui32_max_value = 3000;
@@ -504,16 +502,6 @@ void lcd_execute_menu_config_submenu_wheel_config(void)
       lcd_var_number.ui32_increment_step = 1;
       lcd_var_number.ui8_odometer_field = ODOMETER_FIELD;
       lcd_configurations_print_number(&lcd_var_number);
-
-      if (configuration_variables.ui8_units_type)
-      {
-        // imperial
-        configuration_variables.ui16_wheel_perimeter = (uint16_t) (((float) ui16_wheel_perimeter) * 1.6);
-      }
-      else
-      {
-        configuration_variables.ui16_wheel_perimeter = ui16_wheel_perimeter;
-      }
     break;
 
     // menu to choose units type
@@ -1071,31 +1059,37 @@ void lcd_execute_menu_config_submenu_various (void)
     // set odometer
     case 2:
       ui32_odometer_x10 = configuration_variables.ui32_odometer_x10;
-      
+
       if (configuration_variables.ui8_units_type)
       {
         // imperial
         ui32_odometer_x10 = (uint16_t) (((float) ui32_odometer_x10) / 1.6);
-      }
 
-      lcd_var_number.p_var_number = &ui32_odometer_x10;
-      lcd_var_number.ui8_size = 32;
-      lcd_var_number.ui8_decimal_digit = 0;
-      lcd_var_number.ui32_max_value = 4294967295;
-      lcd_var_number.ui32_min_value = 0;
-      lcd_var_number.ui32_increment_step = 25;
-      lcd_var_number.ui8_odometer_field = ODOMETER_FIELD;
-      lcd_configurations_print_number(&lcd_var_number);
-
-      if (configuration_variables.ui8_units_type)
-      {
-        // imperial
+        lcd_var_number.p_var_number = &ui32_odometer_x10;
+        lcd_var_number.ui8_size = 32;
+        lcd_var_number.ui8_decimal_digit = 1;
+        lcd_var_number.ui32_max_value = 4294967295;
+        lcd_var_number.ui32_min_value = 0;
+        lcd_var_number.ui32_increment_step = 25;
+        lcd_var_number.ui8_odometer_field = ODOMETER_FIELD;
+        lcd_configurations_print_number(&lcd_var_number);
+        
         configuration_variables.ui32_odometer_x10 = (uint16_t) (((float) ui32_odometer_x10) * 1.6);
         lcd_enable_odo_symbol(1);
         lcd_enable_mil_symbol(1);
       }
       else
       {
+        // metric
+        lcd_var_number.p_var_number = &ui32_odometer_x10;
+        lcd_var_number.ui8_size = 32;
+        lcd_var_number.ui8_decimal_digit = 1;
+        lcd_var_number.ui32_max_value = 4294967295;
+        lcd_var_number.ui32_min_value = 0;
+        lcd_var_number.ui32_increment_step = 25;
+        lcd_var_number.ui8_odometer_field = ODOMETER_FIELD;
+        lcd_configurations_print_number(&lcd_var_number);
+        
         configuration_variables.ui32_odometer_x10 = ui32_odometer_x10;
         lcd_enable_odo_symbol(1);
         lcd_enable_km_symbol(1);
@@ -1372,20 +1366,18 @@ void lights_state (void)
     if (ui8_lights_state == 0)
     {
       ui8_lights_state = 1;
-      lcd_lights_symbol = 1;
+      lcd_set_backlight_intensity (configuration_variables.ui8_lcd_backlight_on_brightness); 
       motor_controller_data.ui8_lights = 1;
     }
     else
     {
       ui8_lights_state = 0;
-      lcd_lights_symbol = 0;                                                                                                    // Make lcd_enable_lights_symbol ()
+      lcd_set_backlight_intensity (configuration_variables.ui8_lcd_backlight_off_brightness); 
       motor_controller_data.ui8_lights = 0;
     }
   }
-
-  if (ui8_lights_state == 0) { lcd_set_backlight_intensity (configuration_variables.ui8_lcd_backlight_off_brightness); }
-  else { lcd_set_backlight_intensity (configuration_variables.ui8_lcd_backlight_on_brightness); }
-  lcd_enable_lights_symbol (lcd_lights_symbol);
+  
+  lcd_enable_lights_symbol(ui8_lights_state);
 }
 
 void walk_assist_state (void)
@@ -1670,13 +1662,13 @@ void odometer (void)
               if (configuration_variables.ui8_units_type)
               {
                 // imperial units
-                lcd_print (((float) ui32_temp / 1.6), ODOMETER_FIELD, 0);
+                lcd_print (((float) ui32_temp / 1.6), ODOMETER_FIELD, 1);
                 lcd_enable_mil_symbol (1);
               }
               else
               {
                 // metric units
-                lcd_print (ui32_temp, ODOMETER_FIELD, 0);
+                lcd_print (ui32_temp, ODOMETER_FIELD, 1);
                 lcd_enable_km_symbol (1);
               }
             }
@@ -1724,7 +1716,7 @@ void odometer (void)
                   {
                     // imperial units
                     uint32_t ui32_odometer_distance_x10 = (uint32_t) configuration_variables.ui16_odometer_distance_x10;
-                    lcd_print (((float) ui32_odometer_distance_x10 / 1.6), ODOMETER_FIELD, 0);
+                    lcd_print (((float) ui32_odometer_distance_x10 / 1.6), ODOMETER_FIELD, 1);
                     // lcd_enable_dst_symbol (1); TODO: this fails, the symbol just work when we set it to 1 AND speed field number is equal or higher than 10.0. Seems the 3rd digit at left is needed.
                     lcd_enable_mil_symbol (1);
                   }
@@ -2888,12 +2880,9 @@ void lcd_configurations_print_number(var_number_t* p_lcd_var_number)
   }
 
   // draw only at every ui8_lcd_menu_flash_state -- will flash the number on the LCD
-  if((ui8_lcd_menu_flash_state) ||
-      (p_lcd_var_number->ui8_odometer_field == ASSIST_LEVEL_FIELD)) // do not flash on ASSIST_LEVEL_FIELD
+  if((ui8_lcd_menu_flash_state) || (p_lcd_var_number->ui8_odometer_field == ASSIST_LEVEL_FIELD)) // do not flash on ASSIST_LEVEL_FIELD
   {
-    lcd_print(ui32_value,
-               p_lcd_var_number->ui8_odometer_field,
-               p_lcd_var_number->ui8_decimal_digit);
+    lcd_print(ui32_value, p_lcd_var_number->ui8_odometer_field, p_lcd_var_number->ui8_decimal_digit);
   }
 
   buttons_clear_up_click_event();

--- a/src/display/KT-LCD3/lcd.h
+++ b/src/display/KT-LCD3/lcd.h
@@ -50,6 +50,7 @@ typedef struct _configuration_variables
   uint8_t ui8_number_of_assist_levels;
   uint16_t ui16_wheel_perimeter;
   uint8_t ui8_wheel_max_speed;
+  uint8_t ui8_wheel_max_speed_imperial;
   uint8_t ui8_units_type;
   uint32_t ui32_wh_x10_offset;
   uint32_t ui32_wh_x10_100_percent;

--- a/src/display/KT-LCD3/main.h
+++ b/src/display/KT-LCD3/main.h
@@ -26,6 +26,7 @@
 #define DEFAULT_VALUE_WHEEL_PERIMETER_0                             2 // 26'' wheel: 2050mm perimeter (2 + (8 << 8))
 #define DEFAULT_VALUE_WHEEL_PERIMETER_1                             8
 #define DEFAULT_VALUE_WHEEL_MAX_SPEED                               50
+#define DEFAULT_VALUE_WHEEL_MAX_SPEED_IMPERIAL                      20
 #define DEFAULT_VALUE_UNITS_TYPE                                    0 // 0 = km/h and km
 #define DEFAULT_VALUE_WH_OFFSET                                     0
 #define DEFAULT_VALUE_HW_X10_100_PERCENT                            0

--- a/src/display/KT-LCD3/main.h
+++ b/src/display/KT-LCD3/main.h
@@ -26,7 +26,7 @@
 #define DEFAULT_VALUE_WHEEL_PERIMETER_0                             2 // 26'' wheel: 2050mm perimeter (2 + (8 << 8))
 #define DEFAULT_VALUE_WHEEL_PERIMETER_1                             8
 #define DEFAULT_VALUE_WHEEL_MAX_SPEED                               50
-#define DEFAULT_VALUE_UNITS_TYPE                                    0 // 0 = km/h
+#define DEFAULT_VALUE_UNITS_TYPE                                    0 // 0 = km/h and km
 #define DEFAULT_VALUE_WH_OFFSET                                     0
 #define DEFAULT_VALUE_HW_X10_100_PERCENT                            0
 #define DEAFULT_VALUE_SHOW_NUMERIC_BATTERY_SOC                      0


### PR DESCRIPTION
- Changed so that wheel circumference is only settable in millimeters. This is standard on many E-Bike systems.

- Fixed MPH bug in Max Wheel Speed menu where it would not increment. (*)

- Changed menu order under configuration menu 0. It is better the user first selects imperial or metric units and then maximum wheel speed.

(*) Problem: We could not have explicit type casting conversions before and then after incrementation on maximum wheel speed in imperial units. The explicit type conversion of data types, from _float_ to _int_ in this case, would round down after every conversion. Making the incrementation only work some times on some values but mostly not at all. For this to work as intended the _lcd_var_number.ui32_increment_step_ needs to be at least a value of _1.6_, instead of _1_, and also preferably a multiple of _1.6_. This is not possible as the variable _ui32_increment_step_ is an integer. 

Solution: Make only one conversion from a new variable named: _ui8_wheel_max_speed_imperial_.

Exception: When setting the odometer in imperial units there are no substantial rounding errors even though there might be some. The use of explicit type casting conversions works adequate due to the fact that _lcd_var_number.ui32_increment_step_ is equal to _25_, which is much larger than _1.6_.