### PR TITLE
Bug fixes after last merge and improvements 

### DIFF
--- a/src/controller/ebike_app.c
+++ b/src/controller/ebike_app.c
@@ -550,7 +550,7 @@ static void communications_controller (void)
 
           Example of calculation:
           
-          Target: ramp 5 amps per second
+          Target ramp up: 5 amps per second
 
           Every second has 15625 PWM cycles interrupts,
           one ADC battery current step --> 0.625 amps:

--- a/src/controller/ebike_app.h
+++ b/src/controller/ebike_app.h
@@ -52,8 +52,12 @@ typedef struct _configuration_variables
   uint8_t ui8_offroad_power_limit_enabled;
   uint8_t ui8_offroad_power_limit_div25;
   uint8_t ui8_error_states;
-  uint16_t ui16_ADC_battery_current_ramp_up_inverse_step;
+  uint8_t ui8_ramp_up_amps_per_second_x10;
 } struct_configuration_variables;
+
+
+
+extern volatile uint16_t ui16_current_ramp_up_inverse_step;
 
 extern volatile uint8_t ui8_adc_torque_sensor_min_value;
 extern volatile uint8_t ui8_adc_torque_sensor_max_value;

--- a/src/controller/eeprom.h
+++ b/src/controller/eeprom.h
@@ -11,9 +11,12 @@
 
 #include "main.h"
 
+
+
 #define KEY                                                 0xcd
 
 #define EEPROM_BASE_ADDRESS                                 0x4000
+
 #define ADDRESS_KEY                                         EEPROM_BASE_ADDRESS
 #define ADDRESS_ASSIST_LEVEL_FACTOR_X10                     1 + EEPROM_BASE_ADDRESS
 #define ADDRESS_CONFIG_0                                    2 + EEPROM_BASE_ADDRESS
@@ -28,9 +31,10 @@
 #define ADDRESS_OFFROAD_CONFIG                              11 + EEPROM_BASE_ADDRESS
 #define ADDRESS_OFFROAD_SPEED_LIMIT                         12 + EEPROM_BASE_ADDRESS
 #define ADDRESS_OFFROAD_POWER_LIMIT_DIV25                   13 + EEPROM_BASE_ADDRESS
-#define ADRESS_ADC_BATTERY_CURRENT_RAMP_UP_INVERSE_STEP_0   14 + EEPROM_BASE_ADDRESS
-#define ADRESS_ADC_BATTERY_CURRENT_RAMP_UP_INVERSE_STEP_1   15 + EEPROM_BASE_ADDRESS
-#define EEPROM_BYTES_STORED                                 16
+#define ADDRESS_RAMP_UP_AMPS_PER_SECOND_X10                 14 + EEPROM_BASE_ADDRESS
+#define EEPROM_BYTES_STORED                                 15
+
+
 
 void eeprom_init (void);
 void eeprom_init_variables (void);

--- a/src/controller/main.h
+++ b/src/controller/main.h
@@ -55,7 +55,7 @@
 // measuring with a cheap digital hook scale, we found that each torque sensor unit is equal to 0.52 Nm
 // using the scale, was found that each 0.33kg was measured as 1 torque sensor units
 // Force (Nm) = 1Kg * 9.18 * 0.17 (arm cranks size)
-#define PEDAL_TORQUE_X100 52
+#define PEDAL_TORQUE_X100                     52
 
 
 

--- a/src/controller/main.h
+++ b/src/controller/main.h
@@ -13,40 +13,40 @@
 
 //#define DEBUG_UART
 
-#define PWM_CYCLES_COUNTER_MAX                3125    // 5 erps minimum speed; 1/5 = 200ms; 200ms/64us = 3125
-#define PWM_CYCLES_SECOND                     15625L  // 1 / 64us(PWM period)
-#define PWM_DUTY_CYCLE_MAX                    254
-#define PWM_DUTY_CYCLE_MIN                    20
-#define MIDDLE_PWM_DUTY_CYCLE_MAX             (PWM_DUTY_CYCLE_MAX/2)
+#define PWM_CYCLES_COUNTER_MAX                    3125    // 5 erps minimum speed; 1/5 = 200ms; 200ms/64us = 3125
+#define PWM_CYCLES_SECOND                         15625L  // 1 / 64us(PWM period)
+#define PWM_DUTY_CYCLE_MAX                        254
+#define PWM_DUTY_CYCLE_MIN                        20
+#define MIDDLE_PWM_DUTY_CYCLE_MAX                 (PWM_DUTY_CYCLE_MAX/2)
 
 
 
-#define MOTOR_ROTOR_ANGLE_90                  (63  + MOTOR_ROTOR_OFFSET_ANGLE)
-#define MOTOR_ROTOR_ANGLE_150                 (106 + MOTOR_ROTOR_OFFSET_ANGLE)
-#define MOTOR_ROTOR_ANGLE_210                 (148 + MOTOR_ROTOR_OFFSET_ANGLE)
-#define MOTOR_ROTOR_ANGLE_270                 (191 + MOTOR_ROTOR_OFFSET_ANGLE)
-#define MOTOR_ROTOR_ANGLE_330                 (233 + MOTOR_ROTOR_OFFSET_ANGLE)
-#define MOTOR_ROTOR_ANGLE_30                  (20  + MOTOR_ROTOR_OFFSET_ANGLE)
+#define MOTOR_ROTOR_ANGLE_90                      (63  + MOTOR_ROTOR_OFFSET_ANGLE)
+#define MOTOR_ROTOR_ANGLE_150                     (106 + MOTOR_ROTOR_OFFSET_ANGLE)
+#define MOTOR_ROTOR_ANGLE_210                     (148 + MOTOR_ROTOR_OFFSET_ANGLE)
+#define MOTOR_ROTOR_ANGLE_270                     (191 + MOTOR_ROTOR_OFFSET_ANGLE)
+#define MOTOR_ROTOR_ANGLE_330                     (233 + MOTOR_ROTOR_OFFSET_ANGLE)
+#define MOTOR_ROTOR_ANGLE_30                      (20  + MOTOR_ROTOR_OFFSET_ANGLE)
 
 
 
-#define MOTOR_OVER_SPEED_ERPS                 520 // motor max speed, protection max value | 30 points for the sinewave at max speed
-#define MOTOR_OVER_SPEED_ERPS_EXPERIMENTAL    700 // experimental max motor speed to allow a higher cadence
+#define MOTOR_OVER_SPEED_ERPS                     520 // motor max speed, protection max value | 30 points for the sinewave at max speed
+#define MOTOR_OVER_SPEED_ERPS_EXPERIMENTAL        700 // experimental max motor speed to allow a higher cadence
 
 
 
 // Possible values: 0, 1, 2, 3, 4, 5, 6
 // 0 equal to no filtering and no delay, higher values will increase filtering but will also add bigger delay
-#define THROTTLE_FILTER_COEFFICIENT           1
-#define ADC_THROTTLE_THRESHOLD                10  // value in ADC 8 bits step
-#define ADC_TORQUE_SENSOR_THRESHOLD           6   // value in ADC 8 bits step
+#define THROTTLE_FILTER_COEFFICIENT               1
+#define ADC_THROTTLE_THRESHOLD                    10  // value in ADC 8 bits step
+#define ADC_TORQUE_SENSOR_THRESHOLD               6   // value in ADC 8 bits step
 
 
 
 // Max voltage value for throttle, in ADC 8 bits step
 // each ADC 8 bits step = (5V / 256) = 0.0195
-#define ADC_THROTTLE_MIN_VALUE                47
-#define ADC_THROTTLE_MAX_VALUE                176
+#define ADC_THROTTLE_MIN_VALUE                    47
+#define ADC_THROTTLE_MAX_VALUE                    176
 
 
 
@@ -55,7 +55,7 @@
 // measuring with a cheap digital hook scale, we found that each torque sensor unit is equal to 0.52 Nm
 // using the scale, was found that each 0.33kg was measured as 1 torque sensor units
 // Force (Nm) = 1Kg * 9.18 * 0.17 (arm cranks size)
-#define PEDAL_TORQUE_X100                     52
+#define PEDAL_TORQUE_X100                                         52
 
 
 

--- a/src/controller/main.h
+++ b/src/controller/main.h
@@ -30,49 +30,81 @@
 
 
 
+// motor maximum rotation
 #define MOTOR_OVER_SPEED_ERPS                     520 // motor max speed, protection max value | 30 points for the sinewave at max speed
-#define MOTOR_OVER_SPEED_ERPS_EXPERIMENTAL        700 // experimental max motor speed to allow a higher cadence
+#define MOTOR_OVER_SPEED_ERPS_EXPERIMENTAL        700 // experimental motor speed to allow a higher cadence
 
 
 
-// Possible values: 0, 1, 2, 3, 4, 5, 6
-// 0 equal to no filtering and no delay, higher values will increase filtering but will also add bigger delay
-#define THROTTLE_FILTER_COEFFICIENT               1
+// throttle
+#define THROTTLE_FILTER_COEFFICIENT               1   // see note below
 #define ADC_THROTTLE_THRESHOLD                    10  // value in ADC 8 bits step
 #define ADC_TORQUE_SENSOR_THRESHOLD               6   // value in ADC 8 bits step
 
+/*---------------------------------------------------------
+  NOTE: regarding throttle
+
+  Possible values: 0, 1, 2, 3, 4, 5, 6
+  0 equals to no filtering and no delay, higher values 
+  will increase filtering but will also add a bigger delay.
+---------------------------------------------------------*/
 
 
-// Max voltage value for throttle, in ADC 8 bits step
-// each ADC 8 bits step = (5V / 256) = 0.0195
+
+// throttle ADC values
 #define ADC_THROTTLE_MIN_VALUE                    47
 #define ADC_THROTTLE_MAX_VALUE                    176
+
+/*---------------------------------------------------------
+  NOTE: regarding throttle ADC values
+
+  Max voltage value for throttle, in ADC 8 bits step, 
+  each ADC 8 bits step = (5 V / 256) = 0.0195
+---------------------------------------------------------*/
 
 
 
 // Torque sensor
-// Torque (force) value found experimentaly
-// measuring with a cheap digital hook scale, we found that each torque sensor unit is equal to 0.52 Nm
-// using the scale, was found that each 0.33kg was measured as 1 torque sensor units
-// Force (Nm) = 1Kg * 9.18 * 0.17 (arm cranks size)
-#define PEDAL_TORQUE_X100                                         52
+#define PEDAL_TORQUE_X100                         52
+
+/*---------------------------------------------------------
+  NOTE: regarding torque sensor
+
+  Torque (force) value found experimentaly.
+  
+  Measured with a cheap digital hook scale, we found that
+  each torque sensor unit is equal to 0.52 Nm. Using the 
+  scale it was found that 0.33 kg was measured as 1 torque 
+  sensor unit.
+  
+  Force (Nm) = 1 Kg * 9.18 * 0.17 (0.17 = arm cranks size)
+---------------------------------------------------------*/
 
 
 
 // PAS
-#define PAS_NUMBER_MAGNETS                                        20  // PAS_NUMBER_MAGNETS = 20 was validated on August 2018 by Casainho e jbalat
-
-// x = (1/(150RPM/60)) / (0.000064)
-// PAS_ABSOLUTE_MAX_CADENCE_PWM_CYCLE_TICKS = (x / PAS_NUMBER_MAGNETS)
-#define PAS_ABSOLUTE_MAX_CADENCE_PWM_CYCLE_TICKS                  (6250 / PAS_NUMBER_MAGNETS)   // max hard limit to 150RPM PAS cadence
-#define PAS_ABSOLUTE_MIN_CADENCE_PWM_CYCLE_TICKS                  (93750 / PAS_NUMBER_MAGNETS)  // min hard limit to 10RPM PAS cadence
+#define PAS_NUMBER_MAGNETS                                        20 // see note below
 #define PAS_NUMBER_MAGNETS_X2                                     (PAS_NUMBER_MAGNETS * 2)
+#define PAS_ABSOLUTE_MAX_CADENCE_PWM_CYCLE_TICKS                  (6250 / PAS_NUMBER_MAGNETS)   // max hard limit to 150RPM PAS cadence, see note below
+#define PAS_ABSOLUTE_MIN_CADENCE_PWM_CYCLE_TICKS                  (93750 / PAS_NUMBER_MAGNETS)  // min hard limit to 10RPM PAS cadence, see note below
+
+/*---------------------------------------------------------
+  NOTE: regarding PAS
+  
+  PAS_NUMBER_MAGNETS = 20, was validated on August 2018 
+  by Casainho and jbalat
+
+  x = (1/(150RPM/60)) / (0.000064)
+  
+  PAS_ABSOLUTE_MAX_CADENCE_PWM_CYCLE_TICKS = 
+  (x / PAS_NUMBER_MAGNETS)
+---------------------------------------------------------*/
 
 
 
 // Wheel speed sensor
-#define WHEEL_SPEED_SENSOR_MAX_PWM_CYCLE_TICKS                    135   // something like 200m/h with a 6'' wheel
-#define WHEEL_SPEED_SENSOR_MIN_PWM_CYCLE_TICKS                    32767 // could be a bigger number but will make slow detecting wheel stopped
+#define WHEEL_SPEED_SENSOR_MAX_PWM_CYCLE_TICKS                    135   // something like 200 m/h with a 6'' wheel
+#define WHEEL_SPEED_SENSOR_MIN_PWM_CYCLE_TICKS                    32767 // could be a bigger number but will make for a slow detection of stopped wheel speed
 
 
 
@@ -83,12 +115,12 @@
 #define DEFAULT_VALUE_TARGET_BATTERY_MAX_POWER_X10                50  // 500 watts
 #define DEFAULT_VALUE_BATTERY_LOW_VOLTAGE_CUT_OFF_X10_0           134 // 48 V battery, LVC = 39.0 (3.0 * 13): (134 + (1 << 8)) = 390
 #define DEFAULT_VALUE_BATTERY_LOW_VOLTAGE_CUT_OFF_X10_1           1
-#define DEFAULT_VALUE_WHEEL_PERIMETER_0                           2   // 26'' wheel: 2050mm perimeter (2 + (8 << 8))
+#define DEFAULT_VALUE_WHEEL_PERIMETER_0                           2   // 26'' wheel: 2050 mm perimeter (2 + (8 << 8))
 #define DEFAULT_VALUE_WHEEL_PERIMETER_1                           8
-#define DEFAULT_VALUE_WHEEL_MAX_SPEED                             50  // 50km/h
+#define DEFAULT_VALUE_WHEEL_MAX_SPEED                             50  // 50 km/h
 #define DEFAULT_VALUE_CONFIG_1                                    0
 #define DEFAULT_VALUE_OFFROAD_CONFIG                              0
-#define DEFAULT_VALUE_OFFROAD_SPEED_LIMIT                         25  // 25km/h
+#define DEFAULT_VALUE_OFFROAD_SPEED_LIMIT                         25  // 25 km/h
 #define DEFAULT_VALUE_OFFROAD_POWER_LIMIT_DIV25                   10  // 10 * 25 = 250 W
 
 
@@ -97,27 +129,38 @@
 #define DEFAULT_VALUE_RAMP_UP_AMPS_PER_SECOND_X10                 50  // 5.0 amps per second ramp up
 
 
-
-// ADC Battery voltage
-// 0.344 per ADC_8bits step: 17.9V --> ADC_8bits = 52; 40V --> ADC_8bits = 116; this signal atenuated by the opamp 358
+// ADC battery voltage measurement
 #define ADC10BITS_BATTERY_VOLTAGE_PER_ADC_STEP_X512               44
 #define ADC10BITS_BATTERY_VOLTAGE_PER_ADC_STEP_X256               (ADC10BITS_BATTERY_VOLTAGE_PER_ADC_STEP_X512 >> 1)
 #define ADC8BITS_BATTERY_VOLTAGE_PER_ADC_STEP_INVERSE_X256        (ADC10BITS_BATTERY_VOLTAGE_PER_ADC_STEP_X256 << 2)
 
+/*---------------------------------------------------------
+  NOTE: regarding ADC battery voltage measurement
+
+  0.344 per ADC_8bits step:
+  
+  17.9 V -->  ADC_8bits  = 52; 
+  40 V   -->  ADC_8bits  = 116; 
+  
+  This signal is atenuated by the opamp 358.
+---------------------------------------------------------*/
 
 
-// ADC Battery current
-// 1A per 5 steps of ADC_10bits
-#define ADC_BATTERY_CURRENT_PER_ADC_STEP_X512                     102
 
+// ADC battery current measurement and filter
+#define ADC_BATTERY_CURRENT_PER_ADC_STEP_X512                     102 // 1 A per 5 steps of ADC_10bits
 #define ADC_BATTERY_VOLTAGE_MIN                                   (uint8_t) ((float) (BATTERY_LI_ION_CELLS_NUMBER * LI_ION_CELL_VOLTS_0) / ADC8BITS_BATTERY_VOLTAGE_PER_ADC_STEP)
-
-
-
-// Possible values: 0, 1, 2, 3, 4, 5, 6
-// 0 equal to no filtering and no delay, higher values will increase filtering but will also add bigger delay
 #define READ_BATTERY_CURRENT_FILTER_COEFFICIENT                   2
 #define READ_BATTERY_VOLTAGE_FILTER_COEFFICIENT                   2
+
+/*---------------------------------------------------------
+  NOTE: regarding ADC battery current measurement and 
+  filter coefficients 
+
+  Possible values: 0, 1, 2, 3, 4, 5, 6
+  0 equals to no filtering and no delay, higher values 
+  will increase filtering but will also add a bigger delay.
+---------------------------------------------------------*/
 
 
 

--- a/src/controller/main.h
+++ b/src/controller/main.h
@@ -13,44 +13,41 @@
 
 //#define DEBUG_UART
 
-#define PWM_CYCLES_COUNTER_MAX 3125 // 5 erps minimum speed; 1/5 = 200ms; 200ms/64us = 3125
+#define PWM_CYCLES_COUNTER_MAX                3125    // 5 erps minimum speed; 1/5 = 200ms; 200ms/64us = 3125
+#define PWM_CYCLES_SECOND                     15625L  // 1 / 64us(PWM period)
+#define PWM_DUTY_CYCLE_MAX                    254
+#define PWM_DUTY_CYCLE_MIN                    20
+#define MIDDLE_PWM_DUTY_CYCLE_MAX             (PWM_DUTY_CYCLE_MAX/2)
 
-#define PWM_CYCLES_SECOND 15625L // 1 / 64us(PWM period)
 
-#define PWM_DUTY_CYCLE_MAX 254
-#define PWM_DUTY_CYCLE_MIN 20
-#define MIDDLE_PWM_DUTY_CYCLE_MAX (PWM_DUTY_CYCLE_MAX/2)
 
-#define MOTOR_ROTOR_ANGLE_90    (63  + MOTOR_ROTOR_OFFSET_ANGLE)
-#define MOTOR_ROTOR_ANGLE_150   (106 + MOTOR_ROTOR_OFFSET_ANGLE)
-#define MOTOR_ROTOR_ANGLE_210   (148 + MOTOR_ROTOR_OFFSET_ANGLE)
-#define MOTOR_ROTOR_ANGLE_270   (191 + MOTOR_ROTOR_OFFSET_ANGLE)
-#define MOTOR_ROTOR_ANGLE_330   (233 + MOTOR_ROTOR_OFFSET_ANGLE)
-#define MOTOR_ROTOR_ANGLE_30    (20  + MOTOR_ROTOR_OFFSET_ANGLE)
+#define MOTOR_ROTOR_ANGLE_90                  (63  + MOTOR_ROTOR_OFFSET_ANGLE)
+#define MOTOR_ROTOR_ANGLE_150                 (106 + MOTOR_ROTOR_OFFSET_ANGLE)
+#define MOTOR_ROTOR_ANGLE_210                 (148 + MOTOR_ROTOR_OFFSET_ANGLE)
+#define MOTOR_ROTOR_ANGLE_270                 (191 + MOTOR_ROTOR_OFFSET_ANGLE)
+#define MOTOR_ROTOR_ANGLE_330                 (233 + MOTOR_ROTOR_OFFSET_ANGLE)
+#define MOTOR_ROTOR_ANGLE_30                  (20  + MOTOR_ROTOR_OFFSET_ANGLE)
 
-#define MOTOR_OVER_SPEED_ERPS               520 // motor max speed, protection max value | 30 points for the sinewave at max speed
-#define MOTOR_OVER_SPEED_ERPS_EXPERIMENTAL  700 // experimental max motor speed to allow a higher cadence
 
-#define WHEEL_SPEED_PI_CONTROLLER_KP_DIVIDEND	100
-#define WHEEL_SPEED_PI_CONTROLLER_KP_DIVISOR	4
-#define WHEEL_SPEED_PI_CONTROLLER_KI_DIVIDEND	40
-#define WHEEL_SPEED_PI_CONTROLLER_KI_DIVISOR	6
+
+#define MOTOR_OVER_SPEED_ERPS                 520 // motor max speed, protection max value | 30 points for the sinewave at max speed
+#define MOTOR_OVER_SPEED_ERPS_EXPERIMENTAL    700 // experimental max motor speed to allow a higher cadence
+
 
 
 // Possible values: 0, 1, 2, 3, 4, 5, 6
 // 0 equal to no filtering and no delay, higher values will increase filtering but will also add bigger delay
-#define THROTTLE_FILTER_COEFFICIENT     1
-#define ADC_THROTTLE_THRESHOLD          10 // value in ADC 8 bits step
-#define ADC_TORQUE_SENSOR_THRESHOLD     6 // value in ADC 8 bits step
+#define THROTTLE_FILTER_COEFFICIENT           1
+#define ADC_THROTTLE_THRESHOLD                10  // value in ADC 8 bits step
+#define ADC_TORQUE_SENSOR_THRESHOLD           6   // value in ADC 8 bits step
+
 
 
 // Max voltage value for throttle, in ADC 8 bits step
 // each ADC 8 bits step = (5V / 256) = 0.0195
-#define ADC_THROTTLE_MIN_VALUE 47
-#define ADC_THROTTLE_MAX_VALUE 176
+#define ADC_THROTTLE_MIN_VALUE                47
+#define ADC_THROTTLE_MAX_VALUE                176
 
-
-// *************************************************************************** //
 
 
 // Torque sensor
@@ -61,90 +58,72 @@
 #define PEDAL_TORQUE_X100 52
 
 
-// *************************************************************************** //
-
 
 // PAS
-#define PAS_NUMBER_MAGNETS 20 // PAS_NUMBER_MAGNETS = 20 was validated on August 2018 by Casainho e jbalat
+#define PAS_NUMBER_MAGNETS                                        20  // PAS_NUMBER_MAGNETS = 20 was validated on August 2018 by Casainho e jbalat
 
 // x = (1/(150RPM/60)) / (0.000064)
 // PAS_ABSOLUTE_MAX_CADENCE_PWM_CYCLE_TICKS = (x / PAS_NUMBER_MAGNETS)
-#define PAS_ABSOLUTE_MAX_CADENCE_PWM_CYCLE_TICKS  (6250 / PAS_NUMBER_MAGNETS) // max hard limit to 150RPM PAS cadence
-#define PAS_ABSOLUTE_MIN_CADENCE_PWM_CYCLE_TICKS  (93750 / PAS_NUMBER_MAGNETS) // min hard limit to 10RPM PAS cadence
+#define PAS_ABSOLUTE_MAX_CADENCE_PWM_CYCLE_TICKS                  (6250 / PAS_NUMBER_MAGNETS)   // max hard limit to 150RPM PAS cadence
+#define PAS_ABSOLUTE_MIN_CADENCE_PWM_CYCLE_TICKS                  (93750 / PAS_NUMBER_MAGNETS)  // min hard limit to 10RPM PAS cadence
+#define PAS_NUMBER_MAGNETS_X2                                     (PAS_NUMBER_MAGNETS * 2)
 
-#define PAS_NUMBER_MAGNETS_X2 (PAS_NUMBER_MAGNETS * 2)
-
-
-// *************************************************************************** //
 
 
 // Wheel speed sensor
-#define WHEEL_SPEED_SENSOR_MAX_PWM_CYCLE_TICKS  135 // something like 200m/h with a 6'' wheel
-#define WHEEL_SPEED_SENSOR_MIN_PWM_CYCLE_TICKS  32767 // could be a bigger number but will make slow detecting wheel stopped
+#define WHEEL_SPEED_SENSOR_MAX_PWM_CYCLE_TICKS                    135   // something like 200m/h with a 6'' wheel
+#define WHEEL_SPEED_SENSOR_MIN_PWM_CYCLE_TICKS                    32767 // could be a bigger number but will make slow detecting wheel stopped
 
-
-// *************************************************************************** //
 
 
 // EEPROM memory variables default values
-#define DEFAULT_VALUE_ASSIST_LEVEL_FACTOR_X10                     40 // 4.0
+#define DEFAULT_VALUE_ASSIST_LEVEL_FACTOR_X10                     40  // 4.0
 #define DEFAULT_VALUE_CONFIG_0                                    0
-#define DEFAULT_VALUE_BATTERY_MAX_CURRENT                         10 // 10 amps
-#define DEFAULT_VALUE_TARGET_BATTERY_MAX_POWER_X10                50 // 500 watts
+#define DEFAULT_VALUE_BATTERY_MAX_CURRENT                         10  // 10 amps
+#define DEFAULT_VALUE_TARGET_BATTERY_MAX_POWER_X10                50  // 500 watts
 #define DEFAULT_VALUE_BATTERY_LOW_VOLTAGE_CUT_OFF_X10_0           134 // 48 V battery, LVC = 39.0 (3.0 * 13): (134 + (1 << 8)) = 390
 #define DEFAULT_VALUE_BATTERY_LOW_VOLTAGE_CUT_OFF_X10_1           1
-#define DEFAULT_VALUE_WHEEL_PERIMETER_0                           2 // 26'' wheel: 2050mm perimeter (2 + (8 << 8))
+#define DEFAULT_VALUE_WHEEL_PERIMETER_0                           2   // 26'' wheel: 2050mm perimeter (2 + (8 << 8))
 #define DEFAULT_VALUE_WHEEL_PERIMETER_1                           8
-#define DEFAULT_VALUE_WHEEL_MAX_SPEED                             50 // 50km/h
+#define DEFAULT_VALUE_WHEEL_MAX_SPEED                             50  // 50km/h
 #define DEFAULT_VALUE_CONFIG_1                                    0
 #define DEFAULT_VALUE_OFFROAD_CONFIG                              0
-#define DEFAULT_VALUE_OFFROAD_SPEED_LIMIT                         25 // 25km/h
-#define DEFAULT_VALUE_OFFROAD_POWER_LIMIT_DIV25                   10 // 10 * 25 = 250 W
-#define DEFAULT_VALUE_ADC_BATTERY_CURRENT_RAMP_UP_INVERSE_STEP_0  161 // 1953, see note below, (161 + (7 << 8)) = 1953
-#define DEFAULT_VALUE_ADC_BATTERY_CURRENT_RAMP_UP_INVERSE_STEP_1  7
-
-/*---------------------------------------------------------
-  NOTE: regarding ADC_BATTERY_CURRENT_RAMP_UP_INVERSE_STEP
-
-  Target: ramp 5 amps per second
-
-  Every second has 15625 PWM cycles interrupts,
-  one ADC battery current step --> 0.625 amps:
-
-  5 / 0.625 = 8 (we need to do 8 steps ramp up per second)
-
-  Therefore:
-
-  15625 / 8 = 1953 (our default value)
----------------------------------------------------------*/
+#define DEFAULT_VALUE_OFFROAD_SPEED_LIMIT                         25  // 25km/h
+#define DEFAULT_VALUE_OFFROAD_POWER_LIMIT_DIV25                   10  // 10 * 25 = 250 W
 
 
-// *************************************************************************** //
+
+// default values for ramp up
+#define DEFAULT_VALUE_RAMP_UP_AMPS_PER_SECOND_X10                 50  // 5.0 amps per second ramp up
 
 
-// BATTERY
 
 // ADC Battery voltage
 // 0.344 per ADC_8bits step: 17.9V --> ADC_8bits = 52; 40V --> ADC_8bits = 116; this signal atenuated by the opamp 358
-#define ADC10BITS_BATTERY_VOLTAGE_PER_ADC_STEP_X512 44
-#define ADC10BITS_BATTERY_VOLTAGE_PER_ADC_STEP_X256 (ADC10BITS_BATTERY_VOLTAGE_PER_ADC_STEP_X512 >> 1)
-#define ADC8BITS_BATTERY_VOLTAGE_PER_ADC_STEP_INVERSE_X256 (ADC10BITS_BATTERY_VOLTAGE_PER_ADC_STEP_X256 << 2)
+#define ADC10BITS_BATTERY_VOLTAGE_PER_ADC_STEP_X512               44
+#define ADC10BITS_BATTERY_VOLTAGE_PER_ADC_STEP_X256               (ADC10BITS_BATTERY_VOLTAGE_PER_ADC_STEP_X512 >> 1)
+#define ADC8BITS_BATTERY_VOLTAGE_PER_ADC_STEP_INVERSE_X256        (ADC10BITS_BATTERY_VOLTAGE_PER_ADC_STEP_X256 << 2)
+
+
 
 // ADC Battery current
 // 1A per 5 steps of ADC_10bits
-#define ADC_BATTERY_CURRENT_PER_ADC_STEP_X512 102
+#define ADC_BATTERY_CURRENT_PER_ADC_STEP_X512                     102
 
-#define ADC_BATTERY_VOLTAGE_MIN   (uint8_t) ((float) (BATTERY_LI_ION_CELLS_NUMBER * LI_ION_CELL_VOLTS_0) / ADC8BITS_BATTERY_VOLTAGE_PER_ADC_STEP)
+#define ADC_BATTERY_VOLTAGE_MIN                                   (uint8_t) ((float) (BATTERY_LI_ION_CELLS_NUMBER * LI_ION_CELL_VOLTS_0) / ADC8BITS_BATTERY_VOLTAGE_PER_ADC_STEP)
+
+
 
 // Possible values: 0, 1, 2, 3, 4, 5, 6
 // 0 equal to no filtering and no delay, higher values will increase filtering but will also add bigger delay
-#define READ_BATTERY_CURRENT_FILTER_COEFFICIENT 2
-#define READ_BATTERY_VOLTAGE_FILTER_COEFFICIENT 2
+#define READ_BATTERY_CURRENT_FILTER_COEFFICIENT                   2
+#define READ_BATTERY_VOLTAGE_FILTER_COEFFICIENT                   2
 
 
-// *************************************************************************** //
+
+// motor temperature filter coefficient 
+#define READ_MOTOR_TEMPERATURE_FILTER_COEFFICIENT                 4
 
 
-#define READ_MOTOR_TEMPERATURE_FILTER_COEFFICIENT 4
 
 #endif // _MAIN_H_

--- a/src/controller/motor.c
+++ b/src/controller/motor.c
@@ -700,7 +700,9 @@ void TIM1_CAP_COM_IRQHandler(void) __interrupt(TIM1_CAP_COM_IRQHANDLER)
   }
 
 
+
   /****************************************************************************/
+  
   
   
   // calculate final PWM duty_cycle values to be applied to TIMER1
@@ -763,15 +765,20 @@ void TIM1_CAP_COM_IRQHandler(void) __interrupt(TIM1_CAP_COM_IRQHANDLER)
   TIM1->CCR1L = (uint8_t) (ui8_phase_a_voltage << 1);
 
 
+
   /****************************************************************************/
   
   
-  // Implement ramp up ADC battery current
+  
+  // ramp up ADC battery current
   if (ui8_adc_target_battery_max_current > ui8_controller_adc_battery_max_current)
   {
-    if (ui16_counter_adc_battery_current_ramp_up++ >= p_configuration_variables->ui16_ADC_battery_current_ramp_up_inverse_step)
+    if (ui16_counter_adc_battery_current_ramp_up++ >= ui16_current_ramp_up_inverse_step)
     {
+      // reset counter
       ui16_counter_adc_battery_current_ramp_up = 0;
+      
+      // increment current
       ui8_controller_adc_battery_max_current++;
     }
   }
@@ -782,7 +789,10 @@ void TIM1_CAP_COM_IRQHandler(void) __interrupt(TIM1_CAP_COM_IRQHANDLER)
   }
   
 
+
   /****************************************************************************/
+
+
 
   // calc PAS timming between each positive pulses, in PWM cycles ticks
   // calc PAS on and off timming of each pulse, in PWM cycles ticks
@@ -865,7 +875,9 @@ void TIM1_CAP_COM_IRQHandler(void) __interrupt(TIM1_CAP_COM_IRQHANDLER)
   }
 
 
+
   /****************************************************************************/
+  
   
   
   // calc wheel speed sensor timming between each positive pulses, in PWM cycles ticks

--- a/src/display/KT-LCD3/eeprom.c
+++ b/src/display/KT-LCD3/eeprom.c
@@ -254,11 +254,13 @@ static void eeprom_read_values_to_variables (void)
   ui16_temp += (((uint16_t) ui8_temp << 8) & 0xff00);
   p_configuration_variables->ui16_battery_low_voltage_cut_off_x10 = ui16_temp;
 
+
+  // motor type, motor assistance startup without pedal rotation, temperature limit enabled, tempereture field state
   ui8_temp = FLASH_ReadByte (ADDRESS_CONFIG_0);
   p_configuration_variables->ui8_motor_type = ui8_temp & 3;
   p_configuration_variables->ui8_motor_assistance_startup_without_pedal_rotation = (ui8_temp & 4) >> 2;
-  p_configuration_variables->ui8_temperature_limit_feature_enabled = (ui8_temp & 8) >> 3;
-  p_configuration_variables->ui8_temperature_field_config = (ui8_temp & 48) >> 4;
+  p_configuration_variables->ui8_temperature_limit_feature_enabled = (ui8_temp & 24) >> 3;
+  p_configuration_variables->ui8_temperature_field_state = (ui8_temp & 224) >> 5;
   
   
   // assist levels
@@ -386,10 +388,13 @@ static void variables_to_array (uint8_t *ui8_array)
   ui8_array [18] = p_configuration_variables->ui8_battery_cells_number;
   ui8_array [19] = p_configuration_variables->ui16_battery_low_voltage_cut_off_x10 & 255;
   ui8_array [20] = (p_configuration_variables->ui16_battery_low_voltage_cut_off_x10 >> 8) & 255;
+  
+  
+  // write motor type, motor assistance startup without pedal rotation, temperature limit enabled, tempereture field state
   ui8_array [21] = (p_configuration_variables->ui8_motor_type & 3) |
                   ((p_configuration_variables->ui8_motor_assistance_startup_without_pedal_rotation & 1) << 2) |
-                  ((p_configuration_variables->ui8_temperature_limit_feature_enabled & 1) << 3) |
-                  ((p_configuration_variables->ui8_temperature_field_config & 3) << 4);
+                  ((p_configuration_variables->ui8_temperature_limit_feature_enabled & 3) << 3) |
+                  ((p_configuration_variables->ui8_temperature_field_state & 7) << 5);
 
   for (ui8_index = 0; ui8_index < 9; ui8_index++)
   {

--- a/src/display/KT-LCD3/eeprom.c
+++ b/src/display/KT-LCD3/eeprom.c
@@ -94,30 +94,29 @@ static uint8_t array_default_values [EEPROM_BYTES_STORED] = {
   DEFAULT_VALUE_TOTAL_MINUTE_TTM,                                     // 75 + EEPROM_BASE_ADDRESS (Array index)
   DEFAULT_VALUE_TOTAL_HOUR_TTM_0,                                     // 76 + EEPROM_BASE_ADDRESS (Array index)
   DEFAULT_VALUE_TOTAL_HOUR_TTM_1,                                     // 77 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_ADC_BATTERY_CURRENT_RAMP_UP_INVERSE_STEP_0,           // 78 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_ADC_BATTERY_CURRENT_RAMP_UP_INVERSE_STEP_1,           // 79 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_WALK_ASSIST_FUNCTION_ENABLED,                         // 80 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_WALK_ASSIST_LEVEL_FACTOR_0,                           // 81 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_WALK_ASSIST_LEVEL_FACTOR_1,                           // 82 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_WALK_ASSIST_LEVEL_FACTOR_2,                           // 83 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_WALK_ASSIST_LEVEL_FACTOR_3,                           // 84 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_WALK_ASSIST_LEVEL_FACTOR_4,                           // 85 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_WALK_ASSIST_LEVEL_FACTOR_5,                           // 86 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_WALK_ASSIST_LEVEL_FACTOR_6,                           // 87 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_WALK_ASSIST_LEVEL_FACTOR_7,                           // 88 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_WALK_ASSIST_LEVEL_FACTOR_8,                           // 89 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_WALK_ASSIST_LEVEL_FACTOR_9,                           // 90 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_CRUISE_FUNCTION_ENABLED,                              // 91 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_CRUISE_FUNCTION_SET_TARGET_SPEED_ENABLED,             // 92 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_CRUISE_FUNCTION_TARGET_SPEED_KPH,                     // 93 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_CRUISE_FUNCTION_TARGET_SPEED_MPH,                     // 94 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_SHOW_CRUISE_FUNCTION_SET_TARGET_SPEED,                // 95 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_WHEEL_SPEED_FIELD_STATE,                              // 96 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_SHOW_DISTANCE_DATA_ODOMETER_FIELD,                    // 97 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_SHOW_BATTERY_STATE_ODOMETER_FIELD,                    // 98 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_SHOW_PEDAL_DATA_ODOMETER_FIELD,                       // 99 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_SHOW_TIME_MEASUREMENT_ODOMETER_FIELD,                 // 100 + EEPROM_BASE_ADDRESS (Array index)
-  DEFAULT_VALUE_SHOW_WHEEL_SPEED_ODOMETER_FIELD                       // 101 + EEPROM_BASE_ADDRESS (Array index)
+  DEFAULT_VALUE_RAMP_UP_AMPS_PER_SECOND_X10,                          // 78 + EEPROM_BASE_ADDRESS (Array index)
+  DEFAULT_VALUE_WALK_ASSIST_FUNCTION_ENABLED,                         // 79 + EEPROM_BASE_ADDRESS (Array index)
+  DEFAULT_VALUE_WALK_ASSIST_LEVEL_FACTOR_0,                           // 80 + EEPROM_BASE_ADDRESS (Array index)
+  DEFAULT_VALUE_WALK_ASSIST_LEVEL_FACTOR_1,                           // 81 + EEPROM_BASE_ADDRESS (Array index)
+  DEFAULT_VALUE_WALK_ASSIST_LEVEL_FACTOR_2,                           // 82 + EEPROM_BASE_ADDRESS (Array index)
+  DEFAULT_VALUE_WALK_ASSIST_LEVEL_FACTOR_3,                           // 83 + EEPROM_BASE_ADDRESS (Array index)
+  DEFAULT_VALUE_WALK_ASSIST_LEVEL_FACTOR_4,                           // 84 + EEPROM_BASE_ADDRESS (Array index)
+  DEFAULT_VALUE_WALK_ASSIST_LEVEL_FACTOR_5,                           // 85 + EEPROM_BASE_ADDRESS (Array index)
+  DEFAULT_VALUE_WALK_ASSIST_LEVEL_FACTOR_6,                           // 86 + EEPROM_BASE_ADDRESS (Array index)
+  DEFAULT_VALUE_WALK_ASSIST_LEVEL_FACTOR_7,                           // 87 + EEPROM_BASE_ADDRESS (Array index)
+  DEFAULT_VALUE_WALK_ASSIST_LEVEL_FACTOR_8,                           // 88 + EEPROM_BASE_ADDRESS (Array index)
+  DEFAULT_VALUE_WALK_ASSIST_LEVEL_FACTOR_9,                           // 89 + EEPROM_BASE_ADDRESS (Array index)
+  DEFAULT_VALUE_CRUISE_FUNCTION_ENABLED,                              // 90 + EEPROM_BASE_ADDRESS (Array index)
+  DEFAULT_VALUE_CRUISE_FUNCTION_SET_TARGET_SPEED_ENABLED,             // 91 + EEPROM_BASE_ADDRESS (Array index)
+  DEFAULT_VALUE_CRUISE_FUNCTION_TARGET_SPEED_KPH,                     // 92 + EEPROM_BASE_ADDRESS (Array index)
+  DEFAULT_VALUE_CRUISE_FUNCTION_TARGET_SPEED_MPH,                     // 93 + EEPROM_BASE_ADDRESS (Array index)
+  DEFAULT_VALUE_SHOW_CRUISE_FUNCTION_SET_TARGET_SPEED,                // 94 + EEPROM_BASE_ADDRESS (Array index)
+  DEFAULT_VALUE_WHEEL_SPEED_FIELD_STATE,                              // 95 + EEPROM_BASE_ADDRESS (Array index)
+  DEFAULT_VALUE_SHOW_DISTANCE_DATA_ODOMETER_FIELD,                    // 96 + EEPROM_BASE_ADDRESS (Array index)
+  DEFAULT_VALUE_SHOW_BATTERY_STATE_ODOMETER_FIELD,                    // 97 + EEPROM_BASE_ADDRESS (Array index)
+  DEFAULT_VALUE_SHOW_PEDAL_DATA_ODOMETER_FIELD,                       // 98 + EEPROM_BASE_ADDRESS (Array index)
+  DEFAULT_VALUE_SHOW_TIME_MEASUREMENT_ODOMETER_FIELD,                 // 99 + EEPROM_BASE_ADDRESS (Array index)
+  DEFAULT_VALUE_SHOW_WHEEL_SPEED_ODOMETER_FIELD                       // 100 + EEPROM_BASE_ADDRESS (Array index)
 };
 
 
@@ -320,13 +319,8 @@ static void eeprom_read_values_to_variables (void)
   ui32_temp += (((uint32_t) ui8_temp << 16) & 0xff0000);
   p_configuration_variables->ui32_trip_x10 = ui32_temp;
   
-  
-  // ADC battery current ramp up inverse step
-  ui16_temp = FLASH_ReadByte (ADDRESS_ADC_BATTERY_CURRENT_RAMP_UP_INVERSE_STEP_0);
-  ui8_temp = FLASH_ReadByte (ADDRESS_ADC_BATTERY_CURRENT_RAMP_UP_INVERSE_STEP_1);
-  ui16_temp += (((uint16_t) ui8_temp << 8) & 0xff00);
-  p_configuration_variables->ui16_ADC_battery_current_ramp_up_inverse_step = ui16_temp;
-  
+  // ramp up amps per second
+  p_configuration_variables->ui8_ramp_up_amps_per_second_x10 = FLASH_ReadByte (ADDRESS_RAMP_UP_AMPS_PER_SECOND_X10);
   
   // walk assist function
   p_configuration_variables->ui8_walk_assist_function_enabled = FLASH_ReadByte (ADDRESS_WALK_ASSIST_FUNCTION_ENABLED);
@@ -354,13 +348,6 @@ static void eeprom_read_values_to_variables (void)
   p_configuration_variables->ui8_show_pedal_data_odometer_field = FLASH_ReadByte (ADDRESS_SHOW_PEDAL_DATA_ODOMETER_FIELD);
   p_configuration_variables->ui8_show_time_measurement_odometer_field = FLASH_ReadByte (ADDRESS_SHOW_TIME_MEASUREMENT_ODOMETER_FIELD);
   p_configuration_variables->ui8_show_wheel_speed_odometer_field = FLASH_ReadByte (ADDRESS_SHOW_WHEEL_SPEED_ODOMETER_FIELD);
-
-  
-/*     // TEMP TMEP TMEP TEMP TMEP
-    p_configuration_variables->ui8_cruise_temp_pid_p_value = FLASH_ReadByte (ADDRESS_CRUISE_PID_P_VALUE);
-    p_configuration_variables->ui8_cruise_temp_pid_i_value = FLASH_ReadByte (ADDRESS_CRUISE_PID_I_VALUE);
-    p_configuration_variables->ui8_cruise_temp_pid_i_limit_value = FLASH_ReadByte (ADDRESS_CRUISE_PID_I_LIMIT_VALUE);
-    p_configuration_variables->ui8_cruise_temp_pid_d_value = FLASH_ReadByte (ADDRESS_CRUISE_PID_D_VALUE); */
 }
 
 void eeprom_write_variables (void)
@@ -410,6 +397,7 @@ static void variables_to_array (uint8_t *ui8_array)
   }
   ui8_array [31] = p_configuration_variables->ui8_number_of_assist_levels;
   
+  
   // write motor parameters
   ui8_array [32] = p_configuration_variables->ui8_startup_motor_power_boost_feature_enabled;
   ui8_array [33] = p_configuration_variables->ui8_startup_motor_power_boost_state;
@@ -422,18 +410,22 @@ static void variables_to_array (uint8_t *ui8_array)
   ui8_array [45] = p_configuration_variables->ui8_motor_temperature_min_value_to_limit;
   ui8_array [46] = p_configuration_variables->ui8_motor_temperature_max_value_to_limit;
   
+  
   // write battery parameters
   ui8_array [47] = p_configuration_variables->ui16_battery_voltage_reset_wh_counter_x10 & 255;
   ui8_array [48] = (p_configuration_variables->ui16_battery_voltage_reset_wh_counter_x10 >> 8) & 255;
+  
   
   // write display parameters
   ui8_array [49] = p_configuration_variables->ui8_lcd_power_off_time_minutes;
   ui8_array [50] = p_configuration_variables->ui8_lcd_backlight_on_brightness;
   ui8_array [51] = p_configuration_variables->ui8_lcd_backlight_off_brightness;
 
+
   // write battery parameters
   ui8_array [52] = p_configuration_variables->ui16_battery_pack_resistance_x1000 & 255;
   ui8_array [53] = (p_configuration_variables->ui16_battery_pack_resistance_x1000 >> 8) & 255;
+
 
   // write offroad parameters
   ui8_array [54] = p_configuration_variables->ui8_offroad_feature_enabled;
@@ -442,15 +434,18 @@ static void variables_to_array (uint8_t *ui8_array)
   ui8_array [57] = p_configuration_variables->ui8_offroad_power_limit_enabled;
   ui8_array [58] = p_configuration_variables->ui8_offroad_power_limit_div25;
   
+  
   // write odometer variable
   ui8_array [59] = p_configuration_variables->ui32_odometer_x10 & 255;
   ui8_array [60] = (p_configuration_variables->ui32_odometer_x10 >> 8) & 255;
   ui8_array [61] = (p_configuration_variables->ui32_odometer_x10 >> 16) & 255;
   
+  
   // write trip distance variable
   ui8_array [62] = p_configuration_variables->ui32_trip_x10 & 255;
   ui8_array [63] = (p_configuration_variables->ui32_trip_x10 >> 8) & 255;
   ui8_array [64] = (p_configuration_variables->ui32_trip_x10 >> 16) & 255;
+
 
   // write sub menu states so user can resume since last power on
   ui8_array [65] = p_configuration_variables->ui8_odometer_sub_field_state_0;
@@ -461,11 +456,14 @@ static void variables_to_array (uint8_t *ui8_array)
   ui8_array [70] = p_configuration_variables->ui8_odometer_sub_field_state_5;
   ui8_array [71] = p_configuration_variables->ui8_odometer_sub_field_state_6;
   
+  
   // write max wheel speed in imperial units
   ui8_array [72] = p_configuration_variables->ui8_wheel_max_speed_imperial;
   
+  
   // write time measurement field state
   ui8_array [73] = p_configuration_variables->ui8_time_measurement_field_state;
+
 
   // write time measurement values
   ui8_array [74] = p_configuration_variables->ui8_total_second_TTM;
@@ -474,44 +472,36 @@ static void variables_to_array (uint8_t *ui8_array)
   ui8_array [77] = (p_configuration_variables->ui16_total_hour_TTM >> 8) & 255;
   
   
-  // write ADC battery current ramp up inverse step value
-  ui8_array [78] = p_configuration_variables->ui16_ADC_battery_current_ramp_up_inverse_step & 255;
-  ui8_array [79] = (p_configuration_variables->ui16_ADC_battery_current_ramp_up_inverse_step >> 8) & 255;
+  // write ramp up amps per second
+  ui8_array [78] = p_configuration_variables->ui8_ramp_up_amps_per_second_x10;
   
   
   // write walk assist function variables
-  ui8_array [80] = p_configuration_variables->ui8_walk_assist_function_enabled;
+  ui8_array [79] = p_configuration_variables->ui8_walk_assist_function_enabled;
   for (ui8_index = 0; ui8_index < 10; ui8_index++)
   {
-    ui8_array [81 + ui8_index] = p_configuration_variables->ui8_walk_assist_level_factor [ui8_index];
+    ui8_array [80 + ui8_index] = p_configuration_variables->ui8_walk_assist_level_factor [ui8_index];
   }
   
   
   // write cruise function variables
-  ui8_array [91] = p_configuration_variables->ui8_cruise_function_enabled;
-  ui8_array [92] = p_configuration_variables->ui8_cruise_function_set_target_speed_enabled;
-  ui8_array [93] = p_configuration_variables->ui8_cruise_function_target_speed_kph;
-  ui8_array [94] = p_configuration_variables->ui8_cruise_function_target_speed_mph;
-  ui8_array [95] = p_configuration_variables->ui8_show_cruise_function_set_target_speed;  
+  ui8_array [90] = p_configuration_variables->ui8_cruise_function_enabled;
+  ui8_array [91] = p_configuration_variables->ui8_cruise_function_set_target_speed_enabled;
+  ui8_array [92] = p_configuration_variables->ui8_cruise_function_target_speed_kph;
+  ui8_array [93] = p_configuration_variables->ui8_cruise_function_target_speed_mph;
+  ui8_array [94] = p_configuration_variables->ui8_show_cruise_function_set_target_speed;  
   
   
   // write wheel speed field state
-  ui8_array [96] = p_configuration_variables->ui8_wheel_speed_field_state;
+  ui8_array [95] = p_configuration_variables->ui8_wheel_speed_field_state;
   
   
   // write show odometer variables
-  ui8_array [97] = p_configuration_variables->ui8_show_distance_data_odometer_field;
-  ui8_array [98] = p_configuration_variables->ui8_show_battery_state_odometer_field;
-  ui8_array [99] = p_configuration_variables->ui8_show_pedal_data_odometer_field;
-  ui8_array [100] = p_configuration_variables->ui8_show_time_measurement_odometer_field;
-  ui8_array [101] = p_configuration_variables->ui8_show_wheel_speed_odometer_field;
-  
-  
-/*     // write TEMP TEMPMTEPMTEPMTEPMEPTMEMPT
-    ui8_array [102] = p_configuration_variables->ui8_cruise_temp_pid_p_value;
-    ui8_array [103] = p_configuration_variables->ui8_cruise_temp_pid_i_value;
-    ui8_array [104] = p_configuration_variables->ui8_cruise_temp_pid_i_limit_value;
-    ui8_array [105] = p_configuration_variables->ui8_cruise_temp_pid_d_value; */
+  ui8_array [96] = p_configuration_variables->ui8_show_distance_data_odometer_field;
+  ui8_array [97] = p_configuration_variables->ui8_show_battery_state_odometer_field;
+  ui8_array [98] = p_configuration_variables->ui8_show_pedal_data_odometer_field;
+  ui8_array [99] = p_configuration_variables->ui8_show_time_measurement_odometer_field;
+  ui8_array [100] = p_configuration_variables->ui8_show_wheel_speed_odometer_field;
 }
 
 static void eeprom_write_array (uint8_t *p_array, uint8_t ui8_len)

--- a/src/display/KT-LCD3/eeprom.h
+++ b/src/display/KT-LCD3/eeprom.h
@@ -94,31 +94,30 @@
 #define ADDRESS_TOTAL_MINUTE_TTM                                            75 + EEPROM_BASE_ADDRESS
 #define ADDRESS_TOTAL_HOUR_TTM_0                                            76 + EEPROM_BASE_ADDRESS
 #define ADDRESS_TOTAL_HOUR_TTM_1                                            77 + EEPROM_BASE_ADDRESS
-#define ADDRESS_ADC_BATTERY_CURRENT_RAMP_UP_INVERSE_STEP_0                  78 + EEPROM_BASE_ADDRESS
-#define ADDRESS_ADC_BATTERY_CURRENT_RAMP_UP_INVERSE_STEP_1                  79 + EEPROM_BASE_ADDRESS
-#define ADDRESS_WALK_ASSIST_FUNCTION_ENABLED                                80 + EEPROM_BASE_ADDRESS
-#define ADDRESS_WALK_ASSIST_LEVEL_FACTOR_0                                  81 + EEPROM_BASE_ADDRESS
-#define ADDRESS_WALK_ASSIST_LEVEL_FACTOR_1                                  82 + EEPROM_BASE_ADDRESS
-#define ADDRESS_WALK_ASSIST_LEVEL_FACTOR_2                                  83 + EEPROM_BASE_ADDRESS
-#define ADDRESS_WALK_ASSIST_LEVEL_FACTOR_3                                  84 + EEPROM_BASE_ADDRESS
-#define ADDRESS_WALK_ASSIST_LEVEL_FACTOR_4                                  85 + EEPROM_BASE_ADDRESS
-#define ADDRESS_WALK_ASSIST_LEVEL_FACTOR_5                                  86 + EEPROM_BASE_ADDRESS
-#define ADDRESS_WALK_ASSIST_LEVEL_FACTOR_6                                  87 + EEPROM_BASE_ADDRESS
-#define ADDRESS_WALK_ASSIST_LEVEL_FACTOR_7                                  88 + EEPROM_BASE_ADDRESS
-#define ADDRESS_WALK_ASSIST_LEVEL_FACTOR_8                                  89 + EEPROM_BASE_ADDRESS
-#define ADDRESS_WALK_ASSIST_LEVEL_FACTOR_9                                  90 + EEPROM_BASE_ADDRESS
-#define ADDRESS_CRUISE_FUNCTION_ENABLED                                     91 + EEPROM_BASE_ADDRESS
-#define ADDRESS_CRUISE_FUNCTION_SET_TARGET_SPEED_ENABLED                    92 + EEPROM_BASE_ADDRESS
-#define ADDRESS_CRUISE_FUNCTION_TARGET_SPEED_KPH                            93 + EEPROM_BASE_ADDRESS
-#define ADDRESS_CRUISE_FUNCTION_TARGET_SPEED_MPH                            94 + EEPROM_BASE_ADDRESS
-#define ADDRESS_SHOW_CRUISE_FUNCTION_SET_TARGET_SPEED                       95 + EEPROM_BASE_ADDRESS
-#define ADDRESS_WHEEL_SPEED_FIELD_STATE                                     96 + EEPROM_BASE_ADDRESS
-#define ADDRESS_SHOW_DISTANCE_DATA_ODOMETER_FIELD                           97 + EEPROM_BASE_ADDRESS
-#define ADDRESS_SHOW_BATTERY_STATE_ODOMETER_FIELD                           98 + EEPROM_BASE_ADDRESS
-#define ADDRESS_SHOW_PEDAL_DATA_ODOMETER_FIELD                              99 + EEPROM_BASE_ADDRESS
-#define ADDRESS_SHOW_TIME_MEASUREMENT_ODOMETER_FIELD                        100 + EEPROM_BASE_ADDRESS
-#define ADDRESS_SHOW_WHEEL_SPEED_ODOMETER_FIELD                             101 + EEPROM_BASE_ADDRESS
-#define EEPROM_BYTES_STORED                                                 102
+#define ADDRESS_RAMP_UP_AMPS_PER_SECOND_X10                                 78 + EEPROM_BASE_ADDRESS
+#define ADDRESS_WALK_ASSIST_FUNCTION_ENABLED                                79 + EEPROM_BASE_ADDRESS
+#define ADDRESS_WALK_ASSIST_LEVEL_FACTOR_0                                  80 + EEPROM_BASE_ADDRESS
+#define ADDRESS_WALK_ASSIST_LEVEL_FACTOR_1                                  81 + EEPROM_BASE_ADDRESS
+#define ADDRESS_WALK_ASSIST_LEVEL_FACTOR_2                                  82 + EEPROM_BASE_ADDRESS
+#define ADDRESS_WALK_ASSIST_LEVEL_FACTOR_3                                  83 + EEPROM_BASE_ADDRESS
+#define ADDRESS_WALK_ASSIST_LEVEL_FACTOR_4                                  84 + EEPROM_BASE_ADDRESS
+#define ADDRESS_WALK_ASSIST_LEVEL_FACTOR_5                                  85 + EEPROM_BASE_ADDRESS
+#define ADDRESS_WALK_ASSIST_LEVEL_FACTOR_6                                  86 + EEPROM_BASE_ADDRESS
+#define ADDRESS_WALK_ASSIST_LEVEL_FACTOR_7                                  87 + EEPROM_BASE_ADDRESS
+#define ADDRESS_WALK_ASSIST_LEVEL_FACTOR_8                                  88 + EEPROM_BASE_ADDRESS
+#define ADDRESS_WALK_ASSIST_LEVEL_FACTOR_9                                  89 + EEPROM_BASE_ADDRESS
+#define ADDRESS_CRUISE_FUNCTION_ENABLED                                     90 + EEPROM_BASE_ADDRESS
+#define ADDRESS_CRUISE_FUNCTION_SET_TARGET_SPEED_ENABLED                    91 + EEPROM_BASE_ADDRESS
+#define ADDRESS_CRUISE_FUNCTION_TARGET_SPEED_KPH                            92 + EEPROM_BASE_ADDRESS
+#define ADDRESS_CRUISE_FUNCTION_TARGET_SPEED_MPH                            93 + EEPROM_BASE_ADDRESS
+#define ADDRESS_SHOW_CRUISE_FUNCTION_SET_TARGET_SPEED                       94 + EEPROM_BASE_ADDRESS
+#define ADDRESS_WHEEL_SPEED_FIELD_STATE                                     95 + EEPROM_BASE_ADDRESS
+#define ADDRESS_SHOW_DISTANCE_DATA_ODOMETER_FIELD                           96 + EEPROM_BASE_ADDRESS
+#define ADDRESS_SHOW_BATTERY_STATE_ODOMETER_FIELD                           97 + EEPROM_BASE_ADDRESS
+#define ADDRESS_SHOW_PEDAL_DATA_ODOMETER_FIELD                              98 + EEPROM_BASE_ADDRESS
+#define ADDRESS_SHOW_TIME_MEASUREMENT_ODOMETER_FIELD                        99 + EEPROM_BASE_ADDRESS
+#define ADDRESS_SHOW_WHEEL_SPEED_ODOMETER_FIELD                             100 + EEPROM_BASE_ADDRESS
+#define EEPROM_BYTES_STORED                                                 101
 
 
 

--- a/src/display/KT-LCD3/lcd.c
+++ b/src/display/KT-LCD3/lcd.c
@@ -135,7 +135,6 @@ static uint16_t ui16_battery_soc_watts_hour;
 static uint16_t ui16_battery_voltage_soc_x10;
 
 static uint8_t ui8_reset_to_defaults_counter;
-static uint8_t ui8_state_temp_field;
 
 uint8_t ui8_lcd_power_off_time_counter_minutes = 0;
 static uint16_t ui16_lcd_power_off_time_counter = 0;
@@ -461,6 +460,10 @@ void lcd_execute_menu_config (void)
 
       ui8_lcd_menu_config_submenu_active = 0;
       ui8_lcd_menu_config_submenu_state = 0;
+      
+      // set backlight brightness after user has configured settings, looks nicer this way
+      if (ui8_lights_state == 0) { lcd_set_backlight_intensity (configuration_variables.ui8_lcd_backlight_off_brightness); }
+      else { lcd_set_backlight_intensity (configuration_variables.ui8_lcd_backlight_on_brightness); }
     }
   }
 }
@@ -1177,7 +1180,7 @@ void lcd_execute_menu_config_submenu_lcd (void)
       lcd_configurations_print_number(&lcd_var_number);
       configuration_variables.ui8_lcd_backlight_off_brightness = ui8_temp / 5;
       
-      // show user the chosen backlight brightness
+      // show user the chosen backlight brightness, looks nicer this way
       lcd_set_backlight_intensity (configuration_variables.ui8_lcd_backlight_off_brightness);
     break;
 
@@ -1194,7 +1197,7 @@ void lcd_execute_menu_config_submenu_lcd (void)
       lcd_configurations_print_number(&lcd_var_number);
       configuration_variables.ui8_lcd_backlight_on_brightness = ui8_temp / 5;
       
-      // show user the chosen backlight brightness
+      // show user the chosen backlight brightness, looks nicer this way
       lcd_set_backlight_intensity (configuration_variables.ui8_lcd_backlight_on_brightness);
     break;
 
@@ -1208,6 +1211,11 @@ void lcd_execute_menu_config_submenu_lcd (void)
       lcd_var_number.ui32_increment_step = 1;
       lcd_var_number.ui8_odometer_field = ODOMETER_FIELD;
       lcd_configurations_print_number(&lcd_var_number);
+      
+      // set backlight brightness after user has configured settings, looks nicer this way
+      if (ui8_lights_state == 0) { lcd_set_backlight_intensity (configuration_variables.ui8_lcd_backlight_off_brightness); }
+      else { lcd_set_backlight_intensity (configuration_variables.ui8_lcd_backlight_on_brightness); }
+      
     break;
 
     // reset to defaults
@@ -1229,6 +1237,7 @@ void lcd_execute_menu_config_submenu_lcd (void)
         // Turn off LCD
         lcd_power_off (0);
       }
+      
     break;
   }
 
@@ -1557,8 +1566,16 @@ void temperature (void)
     {
       // show motor temperature
       case 1:
-        lcd_print(motor_controller_data.ui8_motor_temperature, TEMPERATURE_FIELD, 1);
-        lcd_enable_temperature_degrees_symbol (1);
+        // check if function enabled
+        if (configuration_variables.ui8_temperature_limit_feature_enabled != 1) 
+        {
+          configuration_variables.ui8_temperature_field_config = 0;
+        }
+        else 
+        {
+          lcd_print (motor_controller_data.ui8_motor_temperature, TEMPERATURE_FIELD, 1);
+          lcd_enable_temperature_degrees_symbol (1);
+        }
       break;
       
       // show battery state of charge watt-hours
@@ -2392,7 +2409,7 @@ void odometer (void)
       case 4:
       
         // check if user has enabled temperature limit function
-        if (configuration_variables.ui8_temperature_limit_feature_enabled == 0)
+        if (configuration_variables.ui8_temperature_limit_feature_enabled != 1)
         {
           // increment odometer field state
           odometer_increase_field_state ();

--- a/src/display/KT-LCD3/lcd.h
+++ b/src/display/KT-LCD3/lcd.h
@@ -60,7 +60,6 @@ typedef struct _configuration_variables
   uint8_t ui8_total_second_TTM;
   uint16_t ui8_total_minute_TTM;
   uint16_t ui16_total_hour_TTM;
-  uint8_t ui8_odometer_sub_field_state;
   uint8_t ui8_odometer_sub_field_state_0;
   uint8_t ui8_odometer_sub_field_state_1;
   uint8_t ui8_odometer_sub_field_state_2;

--- a/src/display/KT-LCD3/lcd.h
+++ b/src/display/KT-LCD3/lcd.h
@@ -99,7 +99,7 @@ typedef struct _configuration_variables
   uint16_t ui16_odometer_distance_x10;
   uint32_t ui32_odometer_x10;
   uint32_t ui32_trip_x10;
-  uint16_t ui16_ADC_battery_current_ramp_up_inverse_step;
+  uint8_t ui8_ramp_up_amps_per_second_x10;
   uint8_t ui8_walk_assist_function_enabled;
   uint8_t ui8_walk_assist_level_factor [10];
   uint8_t ui8_cruise_function_enabled;
@@ -114,6 +114,8 @@ typedef struct _configuration_variables
   uint8_t ui8_show_time_measurement_odometer_field;
   uint8_t ui8_show_wheel_speed_odometer_field;
 } struct_configuration_variables;
+
+
 
 // LCD RAM has 32*8 bits
 #define LCD_FRAME_BUFFER_SIZE 32

--- a/src/display/KT-LCD3/lcd.h
+++ b/src/display/KT-LCD3/lcd.h
@@ -86,7 +86,7 @@ typedef struct _configuration_variables
   uint8_t ui8_temperature_limit_feature_enabled;
   uint8_t ui8_motor_temperature_min_value_to_limit;
   uint8_t ui8_motor_temperature_max_value_to_limit;
-  uint8_t ui8_temperature_field_config;
+  uint8_t ui8_temperature_field_state;
   uint8_t ui8_lcd_power_off_time_minutes;
   uint8_t ui8_lcd_backlight_on_brightness;
   uint8_t ui8_lcd_backlight_off_brightness;

--- a/src/display/KT-LCD3/main.h
+++ b/src/display/KT-LCD3/main.h
@@ -152,6 +152,9 @@
 #define DEFAULT_VALUE_TOTAL_HOUR_TTM_1                              0
 
 
+// default values for ramp up
+#define DEFAULT_VALUE_RAMP_UP_AMPS_PER_SECOND_X10                   50 // 5.0 amps per second ramp up
+
 
 // default values for ADC battery current ramp up inverse step
 #define DEFAULT_VALUE_ADC_BATTERY_CURRENT_RAMP_UP_INVERSE_STEP_0    161 // 1953, see note below, (161 + (7 << 8)) = 1953

--- a/src/display/KT-LCD3/main.h
+++ b/src/display/KT-LCD3/main.h
@@ -59,7 +59,7 @@
 #define DEFAULT_VALUE_BATTERY_CELLS_NUMBER                          13  // 13 --> 48V
 #define DEFAULT_VALUE_BATTERY_LOW_VOLTAGE_CUT_OFF_X10_0             134 // 48 V battery, LVC = 39.0 (3.0 * 13): (134 + (1 << 8))
 #define DEFAULT_VALUE_BATTERY_LOW_VOLTAGE_CUT_OFF_X10_1             1
-#define DEFAULT_VALUE_CONFIG_0                                      0   // ui8_motor_type = 0; ui8_motor_assistance_startup_config = 0
+#define DEFAULT_VALUE_CONFIG_0                                      0   // motor type, assistance without pedal rotation, temperature limit enabled, temperature field state
 
 
 

--- a/src/display/KT-LCD3/uart.c
+++ b/src/display/KT-LCD3/uart.c
@@ -213,6 +213,7 @@ void uart_data_clock (void)
       ui8_tx_buffer[4] = ((p_motor_controller_data->ui8_lights & 1) |
                          ((p_motor_controller_data->ui8_walk_assist_level & 1) << 1) |
                          ((p_motor_controller_data->ui8_offroad_mode & 1) << 2));
+                         
       // battery max current in amps
       ui8_tx_buffer[5] = p_configuration_variables->ui8_battery_max_current;
 
@@ -244,7 +245,8 @@ void uart_data_clock (void)
           // enable/disable motor temperature limit function
           ui8_tx_buffer[7] = ((p_configuration_variables->ui8_motor_type & 3) |
                              ((p_configuration_variables->ui8_motor_assistance_startup_without_pedal_rotation & 1) << 2) |
-                             ((p_configuration_variables->ui8_temperature_limit_feature_enabled & 1) << 3));
+                             ((p_configuration_variables->ui8_temperature_limit_feature_enabled & 3) << 3));
+                             
           // motor power boost startup state
           ui8_tx_buffer[8] = p_configuration_variables->ui8_startup_motor_power_boost_state;
         break;

--- a/src/display/KT-LCD3/uart.c
+++ b/src/display/KT-LCD3/uart.c
@@ -116,7 +116,7 @@ void uart_data_clock (void)
 
       // send a variable for each package sent but first verify if the last one was received otherwise, keep repeating
       // keep cycling so all variables are sent
-      #define VARIABLE_ID_MAX_NUMBER 11
+      #define VARIABLE_ID_MAX_NUMBER 10
       if ((ui8_rx_buffer [1]) == ui8_master_comm_package_id) // last package data ID was receipt, so send the next one
       {
         ui8_master_comm_package_id = (ui8_master_comm_package_id + 1) % VARIABLE_ID_MAX_NUMBER;
@@ -283,19 +283,16 @@ void uart_data_clock (void)
         break;
         
         case 9:
-          // ADC battery current ramp up inverse step
-          ui8_tx_buffer[7] = (uint8_t) (p_configuration_variables->ui16_ADC_battery_current_ramp_up_inverse_step & 0xff);
-          ui8_tx_buffer[8] = (uint8_t) (p_configuration_variables->ui16_ADC_battery_current_ramp_up_inverse_step >> 8);
-        break;
-        
-        case 10:
+          // ramp up, amps per second
+          ui8_tx_buffer[7] = p_configuration_variables->ui8_ramp_up_amps_per_second_x10;
+          // cruise target speed
           if (p_configuration_variables->ui8_cruise_function_set_target_speed_enabled)
           {
-            ui8_tx_buffer[7] = p_configuration_variables->ui8_cruise_function_target_speed_kph;
+            ui8_tx_buffer[8] = p_configuration_variables->ui8_cruise_function_target_speed_kph;
           }
           else
           {
-            ui8_tx_buffer[7] = 0;
+            ui8_tx_buffer[8] = 0;
           }
         break;
         


### PR DESCRIPTION
This pull request consists of bug fixes and a new setup for the temperature field. 

**Changelog:**

- Fixed bug that did not set the screen brightness until user toggles lights
- Improved screen brightness setup, now the user immediately sees the screen brightness during setup
- Fixed bug that did not show imperial units in the new Wheel Speed sub menu in the odometer field
- Implemented a safer cruise/walk assist toggle
- Developed a better Main Screen Setup with more custom settings
- It is now possible to set what to display in the temperature field
- Removed the quick-change-temperature-field
- Optimized UART communication since last merge
- Made overall improvements: faster and takes up less space
- Changed the motor acceleration to amps per second, more intuitive
- Implemented an enable/disable throttle toggle. This maybe makes two hex versions for the motor controller unnecessary as user can toggle the function on or off via firmware
- Some other smaller fixes