### PR TITLE
Revert "UART optimization"

### DIFF
--- a/src/controller/ebike_app.c
+++ b/src/controller/ebike_app.c
@@ -99,20 +99,20 @@ volatile uint32_t   ui32_wheel_speed_sensor_tick_counter = 0;
 volatile struct_configuration_variables m_configuration_variables;
 
 // variables for UART
-volatile uint8_t  ui8_received_package_flag = 0;
-volatile uint8_t  ui8_rx_buffer[11];
-volatile uint8_t  ui8_rx_counter = 0;
-volatile uint8_t  ui8_tx_buffer[26];
-volatile uint8_t  ui8_tx_counter = 0;
-volatile uint8_t  ui8_i;
-volatile uint8_t  ui8_checksum;
-volatile uint8_t  ui8_byte_received;
-volatile uint8_t  ui8_state_machine = 0;
-volatile uint8_t  ui8_uart_received_first_package = 0;
-static uint16_t   ui16_crc_rx;
-static uint16_t   ui16_crc_tx;
-static uint8_t    ui8_message_ID_TX = 0;
-static uint8_t    ui8_message_ID_RX = 0;
+volatile uint8_t ui8_received_package_flag = 0;
+volatile uint8_t ui8_rx_buffer[11];
+volatile uint8_t ui8_rx_counter = 0;
+volatile uint8_t ui8_tx_buffer[26];
+volatile uint8_t ui8_tx_counter = 0;
+volatile uint8_t ui8_i;
+volatile uint8_t ui8_checksum;
+volatile uint8_t ui8_byte_received;
+volatile uint8_t ui8_state_machine = 0;
+volatile uint8_t ui8_uart_received_first_package = 0;
+static uint16_t  ui16_crc_rx;
+static uint16_t  ui16_crc_tx;
+static uint8_t   ui8_master_comm_package_id = 0;
+static uint8_t   ui8_slave_comm_package_id = 0;
 
 
 uint8_t ui8_tstr_state_machine = STATE_NO_PEDALLING;
@@ -137,7 +137,6 @@ static void ebike_app_set_target_adc_battery_max_current (uint8_t ui8_value);
 
 static void communications_controller (void);
 static void uart_send_package (void);
-static void uart_receive_package (void);
 
 static void throttle_read (void);
 static void read_pas_cadence (void);
@@ -449,165 +448,132 @@ static void ebike_control_motor (void)
 
 static void communications_controller (void)
 {
-#ifndef DEBUG_UART
-
-  uart_receive_package();
-
-  uart_send_package ();
-
-#endif
-}
-
-static void uart_receive_package(void)
-{
   uint32_t ui32_temp;
-  
+
+#ifndef DEBUG_UART
   if (ui8_received_package_flag)
   {
     // verify crc of the package
     ui16_crc_rx = 0xffff;
-    
-    for (ui8_i = 0; ui8_i <= 5; ui8_i++)
+    for (ui8_i = 0; ui8_i < 9; ui8_i++)
     {
       crc16 (ui8_rx_buffer[ui8_i], &ui16_crc_rx);
     }
 
     // see if CRC is ok...
-    if (((((uint16_t) ui8_rx_buffer [7]) << 8) + ((uint16_t) ui8_rx_buffer [6])) == ui16_crc_rx)
+    if (((((uint16_t) ui8_rx_buffer [10]) << 8) + ((uint16_t) ui8_rx_buffer [9])) == ui16_crc_rx)
     {
-      // message ID
-      ui8_message_ID_RX = ui8_rx_buffer[1];
-      
+      ui8_master_comm_package_id = ui8_rx_buffer [1];
+
+      // send a variable for each package sent but first verify if the last one was received otherwise, keep repeating
+      // keep cycling so all variables are sent
+      #define VARIABLE_ID_MAX_NUMBER 5
+      if ((ui8_rx_buffer [2]) == ui8_slave_comm_package_id) // last package data ID was receipt, so send the next one
+      {
+        ui8_slave_comm_package_id = (ui8_slave_comm_package_id + 1) % VARIABLE_ID_MAX_NUMBER;
+      }
+
       // assist level
-      m_configuration_variables.ui8_assist_level_factor_x10 = ui8_rx_buffer [2];
+      m_configuration_variables.ui8_assist_level_factor_x10 = ui8_rx_buffer [3];
       
       // lights state
-      m_configuration_variables.ui8_lights = (ui8_rx_buffer [3] & (1 << 0)) ? 1: 0;
+      m_configuration_variables.ui8_lights = (ui8_rx_buffer [4] & (1 << 0)) ? 1: 0;
       
       // set lights
       lights_set_state (m_configuration_variables.ui8_lights);
       
       // walk assist / cruise function 
-      m_configuration_variables.ui8_walk_assist = (ui8_rx_buffer [3] & (1 << 1)) ? 1: 0;
+      m_configuration_variables.ui8_walk_assist = (ui8_rx_buffer [4] & (1 << 1)) ? 1: 0;
       
-      // offroad state
-      m_configuration_variables.ui8_offroad_mode = (ui8_rx_buffer [3]) & (1 << 2) ? 1: 0;
+      // offroad mode
+      m_configuration_variables.ui8_offroad_mode = (ui8_rx_buffer [4]) & (1 << 2) ? 1: 0;
 
-      switch (ui8_message_ID_RX)
+      // battery max current
+      m_configuration_variables.ui8_battery_max_current = ui8_rx_buffer [5];
+      
+      // set max current from battery
+      ebike_app_set_battery_max_current (m_configuration_variables.ui8_battery_max_current);
+      
+      // target battery max power
+      m_configuration_variables.ui8_target_battery_max_power_div25 = ui8_rx_buffer [6];
+
+      switch (ui8_master_comm_package_id)
       {
         case 0:
-        
-          // battery max current
-          m_configuration_variables.ui8_battery_max_current = ui8_rx_buffer [4];
-        
-          // set max current from battery
-          ebike_app_set_battery_max_current (m_configuration_variables.ui8_battery_max_current);
-          
-          // target battery max power
-          m_configuration_variables.ui8_target_battery_max_power_div25 = ui8_rx_buffer [5];
-          
-        break;
-        
-        case 1:
-          
           // battery low voltage cut-off
-          m_configuration_variables.ui16_battery_low_voltage_cut_off_x10 = (((uint16_t) ui8_rx_buffer [5]) << 8) + ((uint16_t) ui8_rx_buffer [4]);
+          m_configuration_variables.ui16_battery_low_voltage_cut_off_x10 = (((uint16_t) ui8_rx_buffer [8]) << 8) + ((uint16_t) ui8_rx_buffer [7]);
           
-          // calculate the value in ADC steps and set it up
+          // calc the value in ADC steps and set it up
           ui32_temp = ((uint32_t) m_configuration_variables.ui16_battery_low_voltage_cut_off_x10 << 8) / ((uint32_t) ADC8BITS_BATTERY_VOLTAGE_PER_ADC_STEP_INVERSE_X256);
           ui32_temp /= 10;
           motor_set_adc_battery_voltage_cut_off ((uint8_t) ui32_temp);
-        
         break;
-        
-        case 2:
-        
+
+        case 1:
           // wheel perimeter
-          m_configuration_variables.ui16_wheel_perimeter = (((uint16_t) ui8_rx_buffer [5]) << 8) + ((uint16_t) ui8_rx_buffer [4]);
-        
+          m_configuration_variables.ui16_wheel_perimeter = (((uint16_t) ui8_rx_buffer [8]) << 8) + ((uint16_t) ui8_rx_buffer [7]);
         break;
-        
-        case 3:
-        
+
+        case 2:
           // wheel max speed
-          m_configuration_variables.ui8_wheel_max_speed = ui8_rx_buffer [4];
-          
-          // nothing
-          ui32_temp = ui8_rx_buffer [5];
-          
+          m_configuration_variables.ui8_wheel_max_speed = ui8_rx_buffer [7];
         break;
-        
-        case 4:
-        
+
+        case 3:
           // type of motor (36 volt, 48 volt or some experimental type)
-          m_configuration_variables.ui8_motor_type = (ui8_rx_buffer [4] & 3);
+          m_configuration_variables.ui8_motor_type = (ui8_rx_buffer [7] & 3);
           
           // motor assistance without pedal rotation enable/disable when startup 
-          m_configuration_variables.ui8_motor_assistance_startup_without_pedal_rotation = (ui8_rx_buffer [4] & 4) >> 2;
+          m_configuration_variables.ui8_motor_assistance_startup_without_pedal_rotation = (ui8_rx_buffer [7] & 4) >> 2;
           
           // motor temperature limit function enable/disable
-          m_configuration_variables.ui8_temperature_limit_feature_enabled = (ui8_rx_buffer [4] & 8) >> 3;
+          m_configuration_variables.ui8_temperature_limit_feature_enabled = (ui8_rx_buffer [7] & 8) >> 3;
           
           // startup motor boost state
-          m_configuration_variables.ui8_startup_motor_power_boost_state = (ui8_rx_buffer [5] & 1);
+          m_configuration_variables.ui8_startup_motor_power_boost_state = (ui8_rx_buffer [8] & 1);
           
           // startup power boost max power limit
-          m_configuration_variables.ui8_startup_motor_power_boost_limit_to_max_power = (ui8_rx_buffer [5] & 2) >> 1;
-        
+          m_configuration_variables.ui8_startup_motor_power_boost_limit_to_max_power = (ui8_rx_buffer [8] & 2) >> 1;
         break;
-        
-        case 5:
-        
+
+        case 4:
           // startup motor power boost
-          m_configuration_variables.ui8_startup_motor_power_boost_assist_level = ui8_rx_buffer [4];
+          m_configuration_variables.ui8_startup_motor_power_boost_assist_level = ui8_rx_buffer [7];
           
           // startup motor power boost time
-          m_configuration_variables.ui8_startup_motor_power_boost_time = ui8_rx_buffer [5];
-        
+          m_configuration_variables.ui8_startup_motor_power_boost_time = ui8_rx_buffer [8];
         break;
-        
-        case 6:
-        
+
+        case 5:
           // startup motor power boost fade time
-          m_configuration_variables.ui8_startup_motor_power_boost_fade_time = ui8_rx_buffer [4];
-          
-          // boost feature enabled
-          m_configuration_variables.ui8_startup_motor_power_boost_feature_enabled = (ui8_rx_buffer [5] & 1);
-        
+          m_configuration_variables.ui8_startup_motor_power_boost_fade_time = ui8_rx_buffer [7];
+          m_configuration_variables.ui8_startup_motor_power_boost_feature_enabled = (ui8_rx_buffer [8] & 1);
         break;
-        
-        case 7:
-        
+
+        case 6:
           // motor temperature min and max values to limit
-          m_configuration_variables.ui8_motor_temperature_min_value_to_limit = ui8_rx_buffer [4];
-          m_configuration_variables.ui8_motor_temperature_max_value_to_limit = ui8_rx_buffer [5];
-        
+          m_configuration_variables.ui8_motor_temperature_min_value_to_limit = ui8_rx_buffer [7];
+          m_configuration_variables.ui8_motor_temperature_max_value_to_limit = ui8_rx_buffer [8];
         break;
-        
-        
-        case 8:
-        
+
+        case 7:
           // offroad mode configuration
-          m_configuration_variables.ui8_offroad_feature_enabled = (ui8_rx_buffer [4] & 1);
-          m_configuration_variables.ui8_offroad_enabled_on_startup = (ui8_rx_buffer [4] & 2) >> 1;
+          m_configuration_variables.ui8_offroad_feature_enabled = (ui8_rx_buffer [7] & 1);
+          m_configuration_variables.ui8_offroad_enabled_on_startup = (ui8_rx_buffer [7] & 2) >> 1;
           
           // offroad mode speed limit
-          m_configuration_variables.ui8_offroad_speed_limit = ui8_rx_buffer [5];
-        
+          m_configuration_variables.ui8_offroad_speed_limit = ui8_rx_buffer [8];
+        break;
+
+        case 8:
+          // offroad mode power limit configuration
+          m_configuration_variables.ui8_offroad_power_limit_enabled = (ui8_rx_buffer [7] & 1);
+          m_configuration_variables.ui8_offroad_power_limit_div25 = ui8_rx_buffer [8];
         break;
         
         case 9:
-          
-          // offroad mode power limit configuration
-          m_configuration_variables.ui8_offroad_power_limit_enabled = (ui8_rx_buffer [4] & 1);
-          m_configuration_variables.ui8_offroad_power_limit_div25 = ui8_rx_buffer [5];
-          
-        break;
-        
-        case 10:
-          
           // ramp up, amps per second
-          m_configuration_variables.ui8_ramp_up_amps_per_second_x10 = ui8_rx_buffer [4];
+          m_configuration_variables.ui8_ramp_up_amps_per_second_x10 = ui8_rx_buffer [7];
           
           // check that value seems correct
           if (m_configuration_variables.ui8_ramp_up_amps_per_second_x10 < 4 || m_configuration_variables.ui8_ramp_up_amps_per_second_x10 > 100)
@@ -638,12 +604,18 @@ static void uart_receive_package(void)
           ---------------------------------------------------------*/
           
           // received target speed for cruise
-          ui16_received_target_wheel_speed_x10 = (uint16_t) (ui8_rx_buffer [5] * 10);
+          ui16_received_target_wheel_speed_x10 = (uint16_t) (ui8_rx_buffer [8] * 10);
+        break;
         
+        default:
+          // nothing
         break;
       }
 
-      // reset flag indicating that we received the full package
+      // verify if any configuration_variables did change and if so, save all of them in the EEPROM
+      eeprom_write_if_values_changed ();
+
+      // signal that we processed the full package
       ui8_received_package_flag = 0;
 
       ui8_uart_received_first_package = 1;
@@ -652,180 +624,134 @@ static void uart_receive_package(void)
     // enable UART2 receive interrupt as we are now ready to receive a new package
     UART2->CR2 |= (1 << 5);
   }
+
+  uart_send_package ();
+#endif
 }
 
 static void uart_send_package(void)
 {
   uint16_t ui16_temp;
 
-  // send the start byte
+  // send the data to the LCD
+  // start up byte
   ui8_tx_buffer[0] = 0x43;
+  ui8_tx_buffer[1] = ui8_master_comm_package_id;
+  ui8_tx_buffer[2] = ui8_slave_comm_package_id;
+
+  ui16_temp = motor_get_adc_battery_voltage_filtered_10b();
+  // adc 10 bits battery voltage
+  ui8_tx_buffer[3] = (ui16_temp & 0xff);
+  ui8_tx_buffer[4] = ((uint8_t) (ui16_temp >> 4)) & 0x30;
+
+  // battery current x5
+  ui8_tx_buffer[5] = (uint8_t) ((float) motor_get_adc_battery_current_filtered_10b() * 0.826);
+
+  // wheel speed
+  ui8_tx_buffer[6] = (uint8_t) (ui16_wheel_speed_x10 & 0xff);
+  ui8_tx_buffer[7] = (uint8_t) (ui16_wheel_speed_x10 >> 8);
+
+  // brake state
+  if(motor_controller_state_is_set(MOTOR_CONTROLLER_STATE_BRAKE))
+  {
+    ui8_tx_buffer[8] |= 1;
+  }
+  else
+  {
+    ui8_tx_buffer[8] &= ~1;
+  }
+
+  if(m_configuration_variables.ui8_temperature_limit_feature_enabled == 1)
+  {
+    ui8_tx_buffer[9] = UI8_ADC_THROTTLE;
+    ui8_tx_buffer[10] = m_configuration_variables.ui8_motor_temperature;
+  }
+  else
+  {
+    // ADC throttle
+    ui8_tx_buffer[9] = UI8_ADC_THROTTLE;
+    // throttle value with offset removed and mapped to 255
+    ui8_tx_buffer[10] = ui8_throttle;
+  }
+
+  // ADC torque_sensor
+  ui8_tx_buffer[11] = UI8_ADC_TORQUE_SENSOR;
   
-  // send the message ID
-  ui8_tx_buffer[1] = ui8_message_ID_TX;
+  // torque sensor value with offset removed and mapped to 255
+  ui8_tx_buffer[12] = ui8_torque_sensor;
   
-  switch (ui8_message_ID_TX)
+  // PAS cadence
+  ui8_tx_buffer[13] = ui8_pas_cadence_rpm;
+  
+  // pedal human power mapped to 255
+  ui8_tx_buffer[14] = ui8_pedal_human_power;
+  
+  // PWM duty_cycle
+  ui8_tx_buffer[15] = ui8_g_duty_cycle;
+  
+  // motor speed in ERPS
+  ui16_temp = ui16_motor_get_motor_speed_erps();
+  ui8_tx_buffer[16] = (uint8_t) (ui16_temp & 0xff);
+  ui8_tx_buffer[17] = (uint8_t) (ui16_temp >> 8);
+  
+  // FOC angle
+  ui8_tx_buffer[18] = ui8_g_foc_angle;
+
+  switch (ui8_slave_comm_package_id)
   {
     case 0:
-      
-      // 10 bits value of battery voltage (ADC)
-      ui16_temp = motor_get_adc_battery_voltage_filtered_10b();
-      
-      ui8_tx_buffer[2] = (ui16_temp & 0xff);
-      ui8_tx_buffer[3] = ((uint8_t) (ui16_temp >> 4)) & 0x30;
-
-      // battery current x5
-      ui8_tx_buffer[4] = (uint8_t) ((float) motor_get_adc_battery_current_filtered_10b() * 0.826);
-    
-    break;
-    
-    case 1:
-    
-      // wheel speed
-      ui8_tx_buffer[2] = (uint8_t) (ui16_wheel_speed_x10 & 0xff);
-      ui8_tx_buffer[3] = (uint8_t) (ui16_wheel_speed_x10 >> 8);
-
-      // braking state
-      if(motor_controller_state_is_set(MOTOR_CONTROLLER_STATE_BRAKE))
-      {
-        ui8_tx_buffer[4] |= 1;
-      }
-      else
-      {
-        ui8_tx_buffer[4] &= ~1;
-      }
-      
-    break;
-    
-    case 2:
-      
-      // temperature limit function
-      if (m_configuration_variables.ui8_temperature_limit_feature_enabled == 1)
-      {
-        ui8_tx_buffer[2] = UI8_ADC_THROTTLE;
-        ui8_tx_buffer[3] = m_configuration_variables.ui8_motor_temperature;
-      }
-      else
-      {
-        // ADC throttle
-        ui8_tx_buffer[2] = UI8_ADC_THROTTLE;
-        
-        // throttle value with offset removed and mapped to 255
-        ui8_tx_buffer[3] = ui8_throttle;
-      }
-
-      // ADC torque_sensor
-      ui8_tx_buffer[4] = UI8_ADC_TORQUE_SENSOR;
-    
-    break;
-    
-    case 3:
-    
-      // torque sensor value with offset removed and mapped to 255
-      ui8_tx_buffer[2] = ui8_torque_sensor;
-      
-      // PAS cadence
-      ui8_tx_buffer[3] = ui8_pas_cadence_rpm;
-      
-      // pedal human power mapped to 255
-      ui8_tx_buffer[4] = ui8_pedal_human_power;
-    
-    break;
-    
-    case 4:
-    
-      // PWM duty_cycle
-      ui8_tx_buffer[2] = ui8_g_duty_cycle;
-      
-      // motor speed in ERPS
-      ui16_temp = ui16_motor_get_motor_speed_erps ();
-      
-      ui8_tx_buffer[3] = (uint8_t) (ui16_temp & 0xff);
-      ui8_tx_buffer[4] = (uint8_t) (ui16_temp >> 8);
-  
-    break;
-    
-    case 5:
-    
-      // wheel_speed_sensor_tick_counter
-      ui8_tx_buffer[2] = (uint8_t) (ui32_wheel_speed_sensor_tick_counter & 0xff);
-      
-      // wheel_speed_sensor_tick_counter
-      ui8_tx_buffer[3] = (uint8_t) ((ui32_wheel_speed_sensor_tick_counter >> 8) & 0xff);
-      
-      // wheel_speed_sensor_tick_counter
-      ui8_tx_buffer[4] = (uint8_t) ((ui32_wheel_speed_sensor_tick_counter >> 16) & 0xff);
-    
-    break;
-    
-    case 6:
-    
-      // FOC angle
-      ui8_tx_buffer[2] = ui8_g_foc_angle;
-      
       // error states
-      ui8_tx_buffer[3] = m_configuration_variables.ui8_error_states;
-      
+      ui8_tx_buffer[19] = m_configuration_variables.ui8_error_states;
+    break;
+
+    case 1:
       // temperature actual limiting value
-      ui8_tx_buffer[4] = m_configuration_variables.ui8_temperature_current_limiting_value;
-    
+      ui8_tx_buffer[19] = m_configuration_variables.ui8_temperature_current_limiting_value;
     break;
-    
-    case 7:
-    
-      // ui16_pedal_torque_x10
-      ui8_tx_buffer[2] = (uint8_t) (ui16_pedal_torque_x10 & 0xff);
-      ui8_tx_buffer[3] = (uint8_t) (ui16_pedal_torque_x10 >> 8);
-      
-      // send nothing
-      ui8_tx_buffer[4] = 0;
-      
+
+    case 2:
+      // wheel_speed_sensor_tick_counter
+      ui8_tx_buffer[19] = (uint8_t) (ui32_wheel_speed_sensor_tick_counter & 0xff);
     break;
-    
-    case 8:
-      
-      // ui16_pedal_power_x10
-      ui8_tx_buffer[2] = (uint8_t) (ui16_pedal_power_x10 & 0xff);
-      ui8_tx_buffer[3] = (uint8_t) (ui16_pedal_power_x10 >> 8);
-      
-      // send nothing
-      ui8_tx_buffer[4] = 0;
-    
+
+    case 3:
+      // wheel_speed_sensor_tick_counter
+      ui8_tx_buffer[19] = (uint8_t) ((ui32_wheel_speed_sensor_tick_counter >> 8) & 0xff);
     break;
-    
+
+    case 4:
+      // wheel_speed_sensor_tick_counter
+      ui8_tx_buffer[19] = (uint8_t) ((ui32_wheel_speed_sensor_tick_counter >> 16) & 0xff);
+    break;
+
     default:
-      
-      // send nothing
-      ui8_tx_buffer[2] = 0;
-      
-      // send nothing
-      ui8_tx_buffer[3] = 0;
-      
-      // send nothing
-      ui8_tx_buffer[4] = 0;
-      
+      // keep at 0
+      ui8_tx_buffer[19] = 0;
     break;
   }
-  
-  // prepare CRC of the package
+
+  // ui16_pedal_torque_x10
+  ui8_tx_buffer[20] = (uint8_t) (ui16_pedal_torque_x10 & 0xff);
+  ui8_tx_buffer[21] = (uint8_t) (ui16_pedal_torque_x10 >> 8);
+
+  // ui16_pedal_power_x10
+  ui8_tx_buffer[22] = (uint8_t) (ui16_pedal_power_x10 & 0xff);
+  ui8_tx_buffer[23] = (uint8_t) (ui16_pedal_power_x10 >> 8);
+
+  // prepare crc of the package
   ui16_crc_tx = 0xffff;
-  
-  for (ui8_i = 0; ui8_i <= 4; ui8_i++)
+  for (ui8_i = 0; ui8_i <= 23; ui8_i++)
   {
     crc16 (ui8_tx_buffer[ui8_i], &ui16_crc_tx);
   }
-  
-  ui8_tx_buffer[5] = (uint8_t) (ui16_crc_tx & 0xff);
-  ui8_tx_buffer[6] = (uint8_t) (ui16_crc_tx >> 8) & 0xff;
+  ui8_tx_buffer[24] = (uint8_t) (ui16_crc_tx & 0xff);
+  ui8_tx_buffer[25] = (uint8_t) (ui16_crc_tx >> 8) & 0xff;
 
   // send the full package to UART
-  for (ui8_i = 0; ui8_i <= 6; ui8_i++)
+  for (ui8_i = 0; ui8_i <= 25; ui8_i++)
   {
     putchar (ui8_tx_buffer[ui8_i]);
   }
-  
-  // increment message ID for next transmission
-  if (++ui8_message_ID_TX > 8) { ui8_message_ID_TX = 0; }
 }
 
 
@@ -1317,7 +1243,7 @@ void UART2_IRQHandler(void) __interrupt(UART2_IRQHANDLER)
       ui8_rx_counter++;
 
       // see if is the last byte of the package
-      if (ui8_rx_counter > 9)
+      if (ui8_rx_counter > 12)
       {
         ui8_rx_counter = 0;
         ui8_state_machine = 0;

--- a/src/display/KT-LCD3/uart.c
+++ b/src/display/KT-LCD3/uart.c
@@ -24,11 +24,11 @@ volatile uint8_t  ui8_i;
 static uint16_t   ui16_crc_rx;
 static uint16_t   ui16_crc_tx;
 static uint8_t    ui8_lcd_variable_id = 0;
+static uint8_t    ui8_master_comm_package_id = 0;
+static uint8_t    ui8_slave_comm_package_id = 0;
 volatile uint8_t  ui8_byte_received;
 volatile uint8_t  ui8_state_machine = 0;
 volatile uint8_t  ui8_uart_received_first_package = 0;
-static uint8_t    ui8_message_ID_TX = 0;
-static uint8_t    ui8_message_ID_RX = 0;
 
 void uart2_init (void)
 {
@@ -75,7 +75,7 @@ void UART2_IRQHandler(void) __interrupt(UART2_IRQHANDLER)
       ui8_rx_counter++;
 
       // see if is the last byte of the package
-      if (ui8_rx_counter > 8)
+      if (ui8_rx_counter > 27)
       {
         ui8_rx_counter = 0;
         ui8_state_machine = 0;
@@ -94,321 +94,233 @@ void UART2_IRQHandler(void) __interrupt(UART2_IRQHANDLER)
 void uart_data_clock (void)
 {
   static uint32_t ui32_wss_tick_temp;
-  uint32_t temp;
   
   struct_motor_controller_data *p_motor_controller_data;
   struct_configuration_variables *p_configuration_variables;
 
   if (ui8_received_package_flag)
   {
-    // validation of the package data, last byte is the checksum
+    // validation of the package data
+    // last byte is the checksum
     ui16_crc_rx = 0xffff;
-    
-    for (ui8_i = 0; ui8_i <= 4; ui8_i++)
+    for (ui8_i = 0; ui8_i <= 23; ui8_i++)
     {
       crc16 (ui8_rx_buffer[ui8_i], &ui16_crc_rx);
     }
 
-    if (((((uint16_t) ui8_rx_buffer [6]) << 8) + ((uint16_t) ui8_rx_buffer [5])) == ui16_crc_rx)
+    if (((((uint16_t) ui8_rx_buffer [25]) << 8) + ((uint16_t) ui8_rx_buffer [24])) == ui16_crc_rx)
     {
       p_motor_controller_data = lcd_get_motor_controller_data ();
       p_configuration_variables = get_configuration_variables ();
-      
-      ui8_message_ID_RX = ui8_rx_buffer[1];
-      
-      switch (ui8_message_ID_RX)
+
+      // send a variable for each package sent but first verify if the last one was received otherwise, keep repeating
+      // keep cycling so all variables are sent
+      #define VARIABLE_ID_MAX_NUMBER 10
+      if ((ui8_rx_buffer [1]) == ui8_master_comm_package_id) // last package data ID was receipt, so send the next one
+      {
+        ui8_master_comm_package_id = (ui8_master_comm_package_id + 1) % VARIABLE_ID_MAX_NUMBER;
+      }
+
+      ui8_slave_comm_package_id = ui8_rx_buffer[2];
+
+      p_motor_controller_data->ui16_adc_battery_voltage = ui8_rx_buffer[3];
+      p_motor_controller_data->ui16_adc_battery_voltage |= ((uint16_t) (ui8_rx_buffer[4] & 0x30)) << 4;
+      p_motor_controller_data->ui8_battery_current_x5 = ui8_rx_buffer[5];
+      p_motor_controller_data->ui16_wheel_speed_x10 = (((uint16_t) ui8_rx_buffer [7]) << 8) + ((uint16_t) ui8_rx_buffer [6]);
+      p_motor_controller_data->ui8_motor_controller_state_2 = ui8_rx_buffer[8];
+      p_motor_controller_data->ui8_braking = p_motor_controller_data->ui8_motor_controller_state_2 & 1;
+
+      if (p_configuration_variables->ui8_temperature_limit_feature_enabled == 1)
+      {
+        p_motor_controller_data->ui8_adc_throttle = ui8_rx_buffer[9];
+        p_motor_controller_data->ui8_motor_temperature = ui8_rx_buffer[10];
+      }
+      else
+      {
+        p_motor_controller_data->ui8_adc_throttle = ui8_rx_buffer[9];
+        p_motor_controller_data->ui8_throttle = ui8_rx_buffer[10];
+      }
+
+      p_motor_controller_data->ui8_adc_pedal_torque_sensor = ui8_rx_buffer[11];
+      p_motor_controller_data->ui8_pedal_torque_sensor = ui8_rx_buffer[12];
+      p_motor_controller_data->ui8_pedal_cadence = ui8_rx_buffer[13];
+      p_motor_controller_data->ui8_pedal_human_power = ui8_rx_buffer[14];
+      p_motor_controller_data->ui8_duty_cycle = ui8_rx_buffer[15];
+      p_motor_controller_data->ui16_motor_speed_erps = (((uint16_t) ui8_rx_buffer [17]) << 8) + ((uint16_t) ui8_rx_buffer [16]);
+      p_motor_controller_data->ui8_foc_angle = ui8_rx_buffer[18];
+
+      switch (ui8_slave_comm_package_id)
       {
         case 0:
-        
-          // 10 bits value of battery voltage (ADC)
-          p_motor_controller_data->ui16_adc_battery_voltage = ui8_rx_buffer[2];
-          p_motor_controller_data->ui16_adc_battery_voltage |= ((uint16_t) (ui8_rx_buffer[3] & 0x30)) << 4;
-          
-          // battery current x5
-          p_motor_controller_data->ui8_battery_current_x5 = ui8_rx_buffer[4];
-        
-        break;
-        
-        case 1:
-          
-          // wheel speed
-          p_motor_controller_data->ui16_wheel_speed_x10 = (((uint16_t) ui8_rx_buffer [3]) << 8) + ((uint16_t) ui8_rx_buffer [2]);
-          
-          // braking state
-          p_motor_controller_data->ui8_motor_controller_state_2 = ui8_rx_buffer[4];
-          p_motor_controller_data->ui8_braking = p_motor_controller_data->ui8_motor_controller_state_2 & 1;
-          
-        break;
-        
-        case 2:
-          
-          // temperature limit function
-          if (p_configuration_variables->ui8_temperature_limit_feature_enabled == 1)
-          {
-            p_motor_controller_data->ui8_adc_throttle = ui8_rx_buffer[2];
-            p_motor_controller_data->ui8_motor_temperature = ui8_rx_buffer[3];
-          }
-          else
-          {
-            // ADC throttle
-            p_motor_controller_data->ui8_adc_throttle = ui8_rx_buffer[2];
-            
-            // throttle value with offset removed and mapped to 255
-            p_motor_controller_data->ui8_throttle = ui8_rx_buffer[3];
-          }
-          
-          // ADC torque_sensor
-          p_motor_controller_data->ui8_adc_pedal_torque_sensor = ui8_rx_buffer[4];
-        
-        break;
-        
-        case 3:
-          
-          // torque sensor value with offset removed and mapped to 255
-          p_motor_controller_data->ui8_pedal_torque_sensor = ui8_rx_buffer[2];
-          
-          // PAS cadence
-          p_motor_controller_data->ui8_pedal_cadence = ui8_rx_buffer[3];
-          
-          // pedal human power mapped to 255
-          p_motor_controller_data->ui8_pedal_human_power = ui8_rx_buffer[4];
-        
-        break;
-        
-        case 4:
-        
-          // PWM duty_cycle
-          p_motor_controller_data->ui8_duty_cycle = ui8_rx_buffer[2];
-          
-          // motor speed in ERPS
-          p_motor_controller_data->ui16_motor_speed_erps = (((uint16_t) ui8_rx_buffer [4]) << 8) + ((uint16_t) ui8_rx_buffer [3]);
-        
-        break;
-        
-        case 5:
-        
-          // wheel_speed_sensor_tick_counter
-          ui32_wss_tick_temp = ((uint32_t) ui8_rx_buffer[2]);
-
-          // wheel_speed_sensor_tick_counter
-          ui32_wss_tick_temp |= (((uint32_t) ui8_rx_buffer[3]) << 8);
-
-          // wheel_speed_sensor_tick_counter
-          ui32_wss_tick_temp |= (((uint32_t) ui8_rx_buffer[4]) << 16);
-          
-          p_motor_controller_data->ui32_wheel_speed_sensor_tick_counter = ui32_wss_tick_temp;
-          
-        break;
-        
-        case 6:
-        
-          // FOC angle
-          p_motor_controller_data->ui8_foc_angle = ui8_rx_buffer[2];
-        
           // error states
-          p_motor_controller_data->ui8_error_states = ui8_rx_buffer[3];
-          
+          p_motor_controller_data->ui8_error_states = ui8_rx_buffer[19];
+        break;
+
+        case 1:
           // temperature actual limiting value
-          p_motor_controller_data->ui8_temperature_current_limiting_value = ui8_rx_buffer[4];
-        
+          p_motor_controller_data->ui8_temperature_current_limiting_value = ui8_rx_buffer[19];
         break;
-        
-        case 7:
-        
-        // ui16_pedal_torque_x10
-        p_motor_controller_data->ui16_pedal_torque_x10 = (((uint16_t) ui8_rx_buffer [3]) << 8) + ((uint16_t) ui8_rx_buffer [2]);
-        
-        // nothing
-        temp = ui8_rx_buffer[4];
-        
+
+        case 2:
+          // wheel_speed_sensor_tick_counter
+          ui32_wss_tick_temp = ((uint32_t) ui8_rx_buffer[19]);
         break;
-        
-        case 8:
-        
-        // ui16_pedal_power_x10
-        p_motor_controller_data->ui16_pedal_power_x10 = (((uint16_t) ui8_rx_buffer [3]) << 8) + ((uint16_t) ui8_rx_buffer [2]);
-        
-        // nothing
-        temp = ui8_rx_buffer[4];
-        
+
+        case 3:
+          // wheel_speed_sensor_tick_counter
+          ui32_wss_tick_temp |= (((uint32_t) ui8_rx_buffer[19]) << 8);
+        break;
+
+        case 4:
+          // wheel_speed_sensor_tick_counter
+          ui32_wss_tick_temp |= (((uint32_t) ui8_rx_buffer[19]) << 16);
+          p_motor_controller_data->ui32_wheel_speed_sensor_tick_counter = ui32_wss_tick_temp;
         break;
       }
-      
-      // reset flag indicating that we received the full package
+
+      // ui16_pedal_torque_x10
+      p_motor_controller_data->ui16_pedal_torque_x10 = (((uint16_t) ui8_rx_buffer [21]) << 8) + ((uint16_t) ui8_rx_buffer [20]);
+      // ui16_pedal_power_x10
+      p_motor_controller_data->ui16_pedal_power_x10 = (((uint16_t) ui8_rx_buffer [23]) << 8) + ((uint16_t) ui8_rx_buffer [22]);
+
+      // signal that we processed the full package
       ui8_received_package_flag = 0;
 
-      // now send data to the motor controller
-      
-      // send start byte
+      // now send the data to the motor controller
+      // start up byte
       ui8_tx_buffer[0] = 0x59;
+      ui8_tx_buffer[1] = ui8_master_comm_package_id;
+      ui8_tx_buffer[2] = ui8_slave_comm_package_id;
       
-      // send message ID
-      ui8_tx_buffer[1] = ui8_message_ID_TX;
-      
-      // send assist level multiplier
+      // assist level
       if (p_motor_controller_data->ui8_walk_assist_level) // if walk assist function is enabled, send walk assist level factor
       {
-        ui8_tx_buffer[2] = p_configuration_variables->ui8_walk_assist_level_factor [(p_configuration_variables->ui8_assist_level)];
+        ui8_tx_buffer[3] = p_configuration_variables->ui8_walk_assist_level_factor [(p_configuration_variables->ui8_assist_level)];
       }
       else if (p_configuration_variables->ui8_assist_level) // send assist level factor for normal operation 
       {
-        ui8_tx_buffer[2] = p_configuration_variables->ui8_assist_level_factor [((p_configuration_variables->ui8_assist_level) - 1)];
+        ui8_tx_buffer[3] = p_configuration_variables->ui8_assist_level_factor [((p_configuration_variables->ui8_assist_level) - 1)];
       }
       else // send nothing 
       {
-        ui8_tx_buffer[2] = 0;
+        ui8_tx_buffer[3] = 0;
       }
-      
-      // send lights state, walk assist level state and offroad state
-      ui8_tx_buffer[3] = ((p_motor_controller_data->ui8_lights & 1) |
+
+      // set lights state
+      // walk assist level state
+      // set offroad state
+      ui8_tx_buffer[4] = ((p_motor_controller_data->ui8_lights & 1) |
                          ((p_motor_controller_data->ui8_walk_assist_level & 1) << 1) |
                          ((p_motor_controller_data->ui8_offroad_mode & 1) << 2));
                          
-      switch (ui8_message_ID_TX)
+      // battery max current in amps
+      ui8_tx_buffer[5] = p_configuration_variables->ui8_battery_max_current;
+
+      // battery power
+      ui8_tx_buffer[6] = p_configuration_variables->ui8_target_max_battery_power_div25;
+
+      switch (ui8_master_comm_package_id)
       {
         case 0:
-          
-          // battery max current in amps
-          ui8_tx_buffer[4] = p_configuration_variables->ui8_battery_max_current;
-          
-          // battery power
-          ui8_tx_buffer[5] = p_configuration_variables->ui8_target_max_battery_power_div25;
-        
-        break;
-        
-        case 1:
-        
           // battery low voltage cut-off
-          ui8_tx_buffer[4] = (uint8_t) (p_configuration_variables->ui16_battery_low_voltage_cut_off_x10 & 0xff);
-          ui8_tx_buffer[5] = (uint8_t) (p_configuration_variables->ui16_battery_low_voltage_cut_off_x10 >> 8);
-          
+          ui8_tx_buffer[7] = (uint8_t) (p_configuration_variables->ui16_battery_low_voltage_cut_off_x10 & 0xff);
+          ui8_tx_buffer[8] = (uint8_t) (p_configuration_variables->ui16_battery_low_voltage_cut_off_x10 >> 8);
         break;
-        
-        case 2:
-        
+
+        case 1:
           // wheel perimeter
-          ui8_tx_buffer[4] = (uint8_t) (p_configuration_variables->ui16_wheel_perimeter & 0xff);
-          ui8_tx_buffer[5] = (uint8_t) (p_configuration_variables->ui16_wheel_perimeter >> 8);
-        
+          ui8_tx_buffer[7] = (uint8_t) (p_configuration_variables->ui16_wheel_perimeter & 0xff);
+          ui8_tx_buffer[8] = (uint8_t) (p_configuration_variables->ui16_wheel_perimeter >> 8);
         break;
-        
-        case 3:
-        
+
+        case 2:
           // wheel max speed
-          ui8_tx_buffer[4] = p_configuration_variables->ui8_wheel_max_speed;
-          
-          // send nothing
-          ui8_tx_buffer[5] = 0;
-        
+          ui8_tx_buffer[7] = p_configuration_variables->ui8_wheel_max_speed;
         break;
-        
-        case 4:
-        
-          // set motor type, enable/disable motor assistance without pedal rotation and enable/disable motor temperature limit function
-          ui8_tx_buffer[4] = ((p_configuration_variables->ui8_motor_type & 3) |
+
+        case 3:
+          // set motor type
+          // enable/disable motor assistance without pedal rotation
+          // enable/disable motor temperature limit function
+          ui8_tx_buffer[7] = ((p_configuration_variables->ui8_motor_type & 3) |
                              ((p_configuration_variables->ui8_motor_assistance_startup_without_pedal_rotation & 1) << 2) |
                              ((p_configuration_variables->ui8_temperature_limit_feature_enabled & 3) << 3));
                              
           // motor power boost startup state
-          ui8_tx_buffer[5] = p_configuration_variables->ui8_startup_motor_power_boost_state;
-          
+          ui8_tx_buffer[8] = p_configuration_variables->ui8_startup_motor_power_boost_state;
         break;
-        
-        case 5:
-        
+
+        case 4:
           // startup motor power boost
-          ui8_tx_buffer[4] = p_configuration_variables->ui8_startup_motor_power_boost_factor [((p_configuration_variables->ui8_assist_level) - 1)];
-          
+          ui8_tx_buffer[7] = p_configuration_variables->ui8_startup_motor_power_boost_factor [((p_configuration_variables->ui8_assist_level) - 1)];
           // startup motor power boost time
-          ui8_tx_buffer[5] = p_configuration_variables->ui8_startup_motor_power_boost_time;
-        
+          ui8_tx_buffer[8] = p_configuration_variables->ui8_startup_motor_power_boost_time;
         break;
-        
-        case 6:
-        
+
+        case 5:
           // startup motor power boost fade time
-          ui8_tx_buffer[4] = p_configuration_variables->ui8_startup_motor_power_boost_fade_time;
-          
+          ui8_tx_buffer[7] = p_configuration_variables->ui8_startup_motor_power_boost_fade_time;
           // boost feature enabled
-          ui8_tx_buffer[5] = (p_configuration_variables->ui8_startup_motor_power_boost_feature_enabled & 1) ? 1 : 0;
-        
+          ui8_tx_buffer[8] = (p_configuration_variables->ui8_startup_motor_power_boost_feature_enabled & 1) ? 1 : 0;
         break;
-        
-        case 7:
-          
+
+        case 6:
           // motor over temperature min and max values to limit
-          ui8_tx_buffer[4] = p_configuration_variables->ui8_motor_temperature_min_value_to_limit;
-          ui8_tx_buffer[5] = p_configuration_variables->ui8_motor_temperature_max_value_to_limit;
-        
+          ui8_tx_buffer[7] = p_configuration_variables->ui8_motor_temperature_min_value_to_limit;
+          ui8_tx_buffer[8] = p_configuration_variables->ui8_motor_temperature_max_value_to_limit;
         break;
-        
-        case 8:
-        
+
+        case 7:
           // offroad mode configuration
-          ui8_tx_buffer[4] = ((p_configuration_variables->ui8_offroad_feature_enabled & 1) |
+          ui8_tx_buffer[7] = ((p_configuration_variables->ui8_offroad_feature_enabled & 1) |
                              ((p_configuration_variables->ui8_offroad_enabled_on_startup & 1) << 1)); 
-          ui8_tx_buffer[5] = p_configuration_variables->ui8_offroad_speed_limit;
-        
+          ui8_tx_buffer[8] = p_configuration_variables->ui8_offroad_speed_limit;
+        break;
+
+        case 8:
+          // offroad mode power limit configuration
+          ui8_tx_buffer[7] = p_configuration_variables->ui8_offroad_power_limit_enabled & 1;
+          ui8_tx_buffer[8] = p_configuration_variables->ui8_offroad_power_limit_div25;
         break;
         
         case 9:
-          
-          // offroad mode power limit configuration
-          ui8_tx_buffer[4] = p_configuration_variables->ui8_offroad_power_limit_enabled & 1;
-          ui8_tx_buffer[5] = p_configuration_variables->ui8_offroad_power_limit_div25;
-        
-        break;
-        
-        case 10:
-        
           // ramp up, amps per second
-          ui8_tx_buffer[4] = p_configuration_variables->ui8_ramp_up_amps_per_second_x10;
-          
+          ui8_tx_buffer[7] = p_configuration_variables->ui8_ramp_up_amps_per_second_x10;
           // cruise target speed
           if (p_configuration_variables->ui8_cruise_function_set_target_speed_enabled)
           {
-            ui8_tx_buffer[5] = p_configuration_variables->ui8_cruise_function_target_speed_kph;
+            ui8_tx_buffer[8] = p_configuration_variables->ui8_cruise_function_target_speed_kph;
           }
           else
           {
-            ui8_tx_buffer[5] = 0;
+            ui8_tx_buffer[8] = 0;
           }
-          
         break;
         
         default:
-          
-          // send nothing
-          ui8_tx_buffer[4] = 0;
-          
-          // send nothing
-          ui8_tx_buffer[5] = 0;
-        
+          ui8_lcd_variable_id = 0;
         break;
       }
 
       // prepare crc of the package
       ui16_crc_tx = 0xffff;
-      
-      for (ui8_i = 0; ui8_i <= 5; ui8_i++)
+      for (ui8_i = 0; ui8_i <= 8; ui8_i++)
       {
         crc16 (ui8_tx_buffer[ui8_i], &ui16_crc_tx);
       }
-      
-      ui8_tx_buffer[6] = (uint8_t) (ui16_crc_tx & 0xff);
-      ui8_tx_buffer[7] = (uint8_t) (ui16_crc_tx >> 8) & 0xff;
+      ui8_tx_buffer[9] = (uint8_t) (ui16_crc_tx & 0xff);
+      ui8_tx_buffer[10] = (uint8_t) (ui16_crc_tx >> 8) & 0xff;
 
       // send the full package to UART
-      for (ui8_i = 0; ui8_i <= 7; ui8_i++)
+      for (ui8_i = 0; ui8_i <= 10; ui8_i++)
       {
         putchar (ui8_tx_buffer[ui8_i]);
       }
-      
-      // increment message ID for next transmission
-      if (++ui8_message_ID_TX > 10) { ui8_message_ID_TX = 0; }
 
       // let's wait for 10 packages, seems that first ADC battery voltage is an incorrect value
-      if (++ui8_uart_received_first_package > 10) { ui8_uart_received_first_package = 10; }
+      ui8_uart_received_first_package++;
+      if (ui8_uart_received_first_package > 10)
+        ui8_uart_received_first_package = 10;
     }
 
     // enable UART2 receive interrupt as we are now ready to receive a new package


### PR DESCRIPTION
Reverts OpenSource-EBike-firmware/TSDZ2-Smart-EBike#88

UART data sent to LCD must keep the same scheme, the data from sensors like torque sensor, current, etc must be kept sent every 100ms to show on 850C LCD and on SW102 LCD that will send the data over Bluetooth.