### PR TITLE
Fixing no power when integrated lights are on

### DIFF
--- a/src/motor.c
+++ b/src/motor.c
@@ -478,7 +478,7 @@ void TIM1_CAP_COM_IRQHandler(void) __interrupt(TIM1_CAP_COM_IRQHANDLER)
   while (!(ADC1->CSR & ADC1_FLAG_EOC)) ;
   ui16_g_adc_battery_current = UI16_ADC_10_BIT_BATTERY_CURRENT;
 
-  // we ignore low values of the battery current < 5 to avoid issues with other consumers than the motor
+  // we ignore low values of the battery current < 5 to avoid issues with other consumers than the motor (such as integrated 6v lights)
   // Piecewise linear is better than a step, to avoid limit cycles.
   // in     --> out
   // 0 -  5 --> 0 - 0
@@ -492,7 +492,6 @@ void TIM1_CAP_COM_IRQHandler(void) __interrupt(TIM1_CAP_COM_IRQHANDLER)
     ui16_g_adc_battery_current -= 5; // 5 - 15 --> 0 - 10
     ui16_g_adc_battery_current += (ui16_g_adc_battery_current >> 1); // multiply by 1.5: 0 - 10 --> 0 - 15
   }
-
     
   // this shoud work but does not.......
 //  ui16_g_adc_battery_current = (((uint16_t) ADC1->DRH) << 8) | ((uint16_t) ADC1->DRL);

--- a/src/motor.c
+++ b/src/motor.c
@@ -484,9 +484,15 @@ void TIM1_CAP_COM_IRQHandler(void) __interrupt(TIM1_CAP_COM_IRQHANDLER)
   // 0 -  5 --> 0 - 0
   // 5 - 15 --> 0 - 15
   if (ui16_g_adc_battery_current <= 5)
+  {
     ui16_g_adc_battery_current = 0;
+  }  
   else if (ui16_g_adc_battery_current <= 15)
-    ui16_g_adc_battery_current = (ui16_g_adc_battery_current + ui16_g_adc_battery_current >> 1) - 5;
+  {
+    ui16_g_adc_battery_current -= 5; // 5 - 15 --> 0 - 10
+    ui16_g_adc_battery_current += (ui16_g_adc_battery_current >> 1); // multiply by 1.5: 0 - 10 --> 0 - 15
+  }
+
     
   // this shoud work but does not.......
 //  ui16_g_adc_battery_current = (((uint16_t) ADC1->DRH) << 8) | ((uint16_t) ADC1->DRL);
@@ -494,7 +500,7 @@ void TIM1_CAP_COM_IRQHandler(void) __interrupt(TIM1_CAP_COM_IRQHANDLER)
   // calculate motor current ADC value
   if (ui8_g_duty_cycle > 0)
   {
-    ui16_g_adc_motor_current = ((ui16_g_adc_battery_current << 6) / ((uint16_t) ui8_g_duty_cycle));
+    ui16_g_adc_motor_current = ((ui16_g_adc_battery_current << 8) / ((uint16_t) ui8_g_duty_cycle));
   }
   else
   {


### PR DESCRIPTION
My attempt to apply the fix suggested by djwlindenaar in "https://github.com/OpenSource-EBike-firmware/TSDZ2-Smart-EBike/pull/128"  to the current V1.0 code.  Seems to run smoothly and performance appears equivalent whether lights are on or off.  

Compared with another fix of updating line 485 to "if (ui8_g_duty_cycle > 10)", I found this version to feel more responsive.

Other past issues where similar issues are referenced:
1.  https://github.com/OpenSource-EBike-firmware/TSDZ2-Smart-EBike/issues/139
2.  https://github.com/OpenSource-EBike-firmware/TSDZ2-Smart-EBike/issues/71
3.  https://github.com/OpenSource-EBike-firmware/TSDZ2-Smart-EBike/issues/94
4.  https://github.com/OpenSource-EBike-firmware/Color_LCD/issues/104