### PR TITLE
Updates to UART Receiver to fix 'Assist Level 3'

### DIFF
--- a/src/ebike_app.c
+++ b/src/ebike_app.c
@@ -123,8 +123,13 @@ static uint16_t     ui16_wheel_speed_x10;
 volatile uint32_t   ui32_wheel_speed_sensor_tick_counter = 0;
 
 // UART
-#define UART_NUMBER_DATA_BYTES_TO_RECEIVE   88
-#define UART_NUMBER_DATA_BYTES_TO_SEND      29
+#define UART_RECEIVE_RINGBUFFER_SIZE   256 // Maximum size - can reduce later
+volatile uint8_t ui8_rx_ringbuffer[UART_RECEIVE_RINGBUFFER_SIZE];
+volatile uint8_t ui8_rx_ringbuffer_read_index = 0;
+volatile uint8_t ui8_rx_ringbuffer_write_index = 0;
+
+#define UART_NUMBER_DATA_BYTES_TO_RECEIVE   256//88
+#define UART_NUMBER_DATA_BYTES_TO_SEND      256//29
 
 volatile uint8_t ui8_received_package_flag = 0;
 volatile uint8_t ui8_rx_buffer[UART_NUMBER_DATA_BYTES_TO_RECEIVE];
@@ -141,6 +146,7 @@ volatile uint8_t ui8_message_ID = 0;
 volatile uint8_t ui8_packet_len;
 static void communications_controller(void);
 static void communications_process_packages(uint8_t ui8_frame_type);
+static void packet_assembler(void);
 
 // system functions
 static void ebike_control_motor(void);
@@ -201,7 +207,16 @@ void ebike_app_controller(void)
   calc_motor_temperature();
   ebike_control_motor();
   communications_controller();
+  packet_assembler();
   check_system();
+}
+
+void reset_rx_buffer(void)
+{
+  ui8_rx_ringbuffer_read_index = 0;
+  ui8_rx_ringbuffer_write_index = 0;
+  ui8_state_machine =0;
+  ui8_received_package_flag =0;
 }
 
 static void ebike_control_motor(void)
@@ -1497,57 +1512,78 @@ static void throttle_read(void)
 }
 
 
-// This is the interrupt that happens when UART2 receives data. We need it to be the fastest possible and so
-// we do: receive every byte and assembly as a package, finally, signal that we have a package to process (on main slow loop)
+// Read the input buffer and assemble data as a package, finally, signal that we have a package to process (on main slow loop)
 // and disable the interrupt. The interrupt should be enable again on main loop, after the package being processed
+static void packet_assembler(void)
+{
+  //if ((uint8_t)ui8_rx_ringbuffer_read_index!=(uint8_t)ui8_rx_ringbuffer_write_index)
+  //{
+    if (ui8_received_package_flag == 0) // only when package were previously processed
+    {
+      while (((uint8_t)(ui8_rx_ringbuffer_read_index+0x1) != (ui8_rx_ringbuffer_write_index)) && ((uint8_t)ui8_rx_ringbuffer_read_index!=(uint8_t)ui8_rx_ringbuffer_write_index))
+      {
+        ui8_byte_received = ui8_rx_ringbuffer[(uint8_t)(ui8_rx_ringbuffer_read_index++)];
+        
+        switch (ui8_state_machine)
+        {
+          case 0:
+          if (ui8_byte_received == 0x59) { // see if we get start package byte
+            ui8_rx_buffer[0] = ui8_byte_received;
+            ui8_state_machine = 1;
+          }
+          else
+            ui8_state_machine = 0;
+          break;
+
+          case 1:
+            ui8_rx_buffer[1] = ui8_byte_received;
+            ui8_rx_len = ui8_byte_received;
+            ui8_state_machine = 2;
+          break;
+
+          case 2:
+          ui8_rx_buffer[ui8_rx_cnt + 2] = ui8_byte_received;
+          ++ui8_rx_cnt;
+
+          if (ui8_rx_cnt >= ui8_rx_len)
+          {
+            ui8_rx_cnt = 0;
+            ui8_state_machine = 0;
+            ui8_received_package_flag = 1; // signal that we have a full package to be processed
+          }
+          break;
+
+          default:
+          break;
+        }
+      }
+    }
+    else // if there was any error, restart our state machine
+    {
+      ui8_rx_cnt = 0;
+      ui8_state_machine = 0;
+    }
+  //}
+}
+
+
+// This is the interrupt that happens when UART2 receives data. We need it to be the fastest possible and so
+// we do: receive every byte and feed into a ringbuffer for the packet assembly routine to consume.
+
 void UART2_RX_IRQHandler(void) __interrupt(UART2_RX_IRQHANDLER)
 {
   if (UART2_GetFlagStatus(UART2_FLAG_RXNE) == SET)
   {
     UART2->SR &= (uint8_t)~(UART2_FLAG_RXNE); // this may be redundant
 
-    if (ui8_received_package_flag == 0) // only when package were previously processed
+    if (((uint8_t)ui8_rx_ringbuffer_write_index + (uint8_t)0x1)!=ui8_rx_ringbuffer_read_index) 
+      ui8_rx_ringbuffer[(uint8_t)(ui8_rx_ringbuffer_write_index++)] = UART2_ReceiveData8();
+    else 
     {
-      ui8_byte_received = UART2_ReceiveData8();
-
-      switch (ui8_state_machine)
-      {
-        case 0:
-        if (ui8_byte_received == 0x59) { // see if we get start package byte
-          ui8_rx_buffer[0] = ui8_byte_received;
-          ui8_state_machine = 1;
-        }
-        else
-          ui8_state_machine = 0;
-        break;
-
-        case 1:
-          ui8_rx_buffer[1] = ui8_byte_received;
-          ui8_rx_len = ui8_byte_received;
-          ui8_state_machine = 2;
-        break;
-
-        case 2:
-        ui8_rx_buffer[ui8_rx_cnt + 2] = ui8_byte_received;
-        ++ui8_rx_cnt;
-
-        if (ui8_rx_cnt >= ui8_rx_len)
-        {
-          ui8_rx_cnt = 0;
-          ui8_state_machine = 0;
-          ui8_received_package_flag = 1; // signal that we have a full package to be processed
-        }
-        break;
-
-        default:
-        break;
-      }
+      (uint8_t)ui8_rx_ringbuffer_read_index++;
+      ui8_rx_ringbuffer[(uint8_t)(ui8_rx_ringbuffer_write_index++)] = UART2_ReceiveData8();
     }
-  }
-  else // if there was any error, restart our state machine
-  {
-    ui8_rx_cnt = 0;
-    ui8_state_machine = 0;
+  
   }
 }
 

--- a/src/ebike_app.c
+++ b/src/ebike_app.c
@@ -123,13 +123,8 @@ static uint16_t     ui16_wheel_speed_x10;
 volatile uint32_t   ui32_wheel_speed_sensor_tick_counter = 0;
 
 // UART
-#define UART_RECEIVE_RINGBUFFER_SIZE   256 // Maximum size - can reduce later
-volatile uint8_t ui8_rx_ringbuffer[UART_RECEIVE_RINGBUFFER_SIZE];
-volatile uint8_t ui8_rx_ringbuffer_read_index = 0;
-volatile uint8_t ui8_rx_ringbuffer_write_index = 0;
-
-#define UART_NUMBER_DATA_BYTES_TO_RECEIVE   256//88
-#define UART_NUMBER_DATA_BYTES_TO_SEND      256//29
+#define UART_NUMBER_DATA_BYTES_TO_RECEIVE   88
+#define UART_NUMBER_DATA_BYTES_TO_SEND      29
 
 volatile uint8_t ui8_received_package_flag = 0;
 volatile uint8_t ui8_rx_buffer[UART_NUMBER_DATA_BYTES_TO_RECEIVE];
@@ -146,7 +141,6 @@ volatile uint8_t ui8_message_ID = 0;
 volatile uint8_t ui8_packet_len;
 static void communications_controller(void);
 static void communications_process_packages(uint8_t ui8_frame_type);
-static void packet_assembler(void);
 
 // system functions
 static void ebike_control_motor(void);
@@ -207,16 +201,7 @@ void ebike_app_controller(void)
   calc_motor_temperature();
   ebike_control_motor();
   communications_controller();
-  packet_assembler();
   check_system();
-}
-
-void reset_rx_buffer(void)
-{
-  ui8_rx_ringbuffer_read_index = 0;
-  ui8_rx_ringbuffer_write_index = 0;
-  ui8_state_machine =0;
-  ui8_received_package_flag =0;
 }
 
 static void ebike_control_motor(void)
@@ -1512,78 +1497,57 @@ static void throttle_read(void)
 }
 
 
-// Read the input buffer and assemble data as a package, finally, signal that we have a package to process (on main slow loop)
-// and disable the interrupt. The interrupt should be enable again on main loop, after the package being processed
-static void packet_assembler(void)
-{
-  //if ((uint8_t)ui8_rx_ringbuffer_read_index!=(uint8_t)ui8_rx_ringbuffer_write_index)
-  //{
-    if (ui8_received_package_flag == 0) // only when package were previously processed
-    {
-      while (((uint8_t)(ui8_rx_ringbuffer_read_index+0x1) != (ui8_rx_ringbuffer_write_index)) && ((uint8_t)ui8_rx_ringbuffer_read_index!=(uint8_t)ui8_rx_ringbuffer_write_index))
-      {
-        ui8_byte_received = ui8_rx_ringbuffer[(uint8_t)(ui8_rx_ringbuffer_read_index++)];
-        
-        switch (ui8_state_machine)
-        {
-          case 0:
-          if (ui8_byte_received == 0x59) { // see if we get start package byte
-            ui8_rx_buffer[0] = ui8_byte_received;
-            ui8_state_machine = 1;
-          }
-          else
-            ui8_state_machine = 0;
-          break;
-
-          case 1:
-            ui8_rx_buffer[1] = ui8_byte_received;
-            ui8_rx_len = ui8_byte_received;
-            ui8_state_machine = 2;
-          break;
-
-          case 2:
-          ui8_rx_buffer[ui8_rx_cnt + 2] = ui8_byte_received;
-          ++ui8_rx_cnt;
-
-          if (ui8_rx_cnt >= ui8_rx_len)
-          {
-            ui8_rx_cnt = 0;
-            ui8_state_machine = 0;
-            ui8_received_package_flag = 1; // signal that we have a full package to be processed
-          }
-          break;
-
-          default:
-          break;
-        }
-      }
-    }
-    else // if there was any error, restart our state machine
-    {
-      ui8_rx_cnt = 0;
-      ui8_state_machine = 0;
-    }
-  //}
-}
-
-
 // This is the interrupt that happens when UART2 receives data. We need it to be the fastest possible and so
-// we do: receive every byte and feed into a ringbuffer for the packet assembly routine to consume.
-
+// we do: receive every byte and assembly as a package, finally, signal that we have a package to process (on main slow loop)
+// and disable the interrupt. The interrupt should be enable again on main loop, after the package being processed
 void UART2_RX_IRQHandler(void) __interrupt(UART2_RX_IRQHANDLER)
 {
   if (UART2_GetFlagStatus(UART2_FLAG_RXNE) == SET)
   {
     UART2->SR &= (uint8_t)~(UART2_FLAG_RXNE); // this may be redundant
 
-    if (((uint8_t)ui8_rx_ringbuffer_write_index + (uint8_t)0x1)!=ui8_rx_ringbuffer_read_index) 
-      ui8_rx_ringbuffer[(uint8_t)(ui8_rx_ringbuffer_write_index++)] = UART2_ReceiveData8();
-    else 
+    if (ui8_received_package_flag == 0) // only when package were previously processed
     {
-      (uint8_t)ui8_rx_ringbuffer_read_index++;
-      ui8_rx_ringbuffer[(uint8_t)(ui8_rx_ringbuffer_write_index++)] = UART2_ReceiveData8();
+      ui8_byte_received = UART2_ReceiveData8();
+
+      switch (ui8_state_machine)
+      {
+        case 0:
+        if (ui8_byte_received == 0x59) { // see if we get start package byte
+          ui8_rx_buffer[0] = ui8_byte_received;
+          ui8_state_machine = 1;
+        }
+        else
+          ui8_state_machine = 0;
+        break;
+
+        case 1:
+          ui8_rx_buffer[1] = ui8_byte_received;
+          ui8_rx_len = ui8_byte_received;
+          ui8_state_machine = 2;
+        break;
+
+        case 2:
+        ui8_rx_buffer[ui8_rx_cnt + 2] = ui8_byte_received;
+        ++ui8_rx_cnt;
+
+        if (ui8_rx_cnt >= ui8_rx_len)
+        {
+          ui8_rx_cnt = 0;
+          ui8_state_machine = 0;
+          ui8_received_package_flag = 1; // signal that we have a full package to be processed
+        }
+        break;
+
+        default:
+        break;
+      }
     }
-  
+  }
+  else // if there was any error, restart our state machine
+  {
+    ui8_rx_cnt = 0;
+    ui8_state_machine = 0;
   }
 }
 

--- a/src/ebike_app.h
+++ b/src/ebike_app.h
@@ -77,6 +77,7 @@ extern volatile uint8_t ui8_g_throttle;
 extern volatile uint16_t ui16_g_adc_current_offset;
 
 void ebike_app_controller (void);
+void reset_rx_buffer(void);
 struct_config_vars* get_configuration_variables (void);
 
 #endif /* _EBIKE_APP_H_ */

--- a/src/ebike_app.h
+++ b/src/ebike_app.h
@@ -77,7 +77,7 @@ extern volatile uint8_t ui8_g_throttle;
 extern volatile uint16_t ui16_g_adc_current_offset;
 
 void ebike_app_controller (void);
-void reset_rx_buffer(void);
+
 struct_config_vars* get_configuration_variables (void);
 
 #endif /* _EBIKE_APP_H_ */

--- a/src/ebike_app.h
+++ b/src/ebike_app.h
@@ -77,7 +77,6 @@ extern volatile uint8_t ui8_g_throttle;
 extern volatile uint16_t ui16_g_adc_current_offset;
 
 void ebike_app_controller (void);
-void reset_rx_buffer(void);
 struct_config_vars* get_configuration_variables (void);
 
 #endif /* _EBIKE_APP_H_ */

--- a/src/main.c
+++ b/src/main.c
@@ -78,6 +78,7 @@ int main(void)
   pwm_init_bipolar_4q();
   motor_init();
   enableInterrupts();
+  reset_rx_buffer();
 
   while(1)
   {

--- a/src/main.c
+++ b/src/main.c
@@ -78,7 +78,6 @@ int main(void)
   pwm_init_bipolar_4q();
   motor_init();
   enableInterrupts();
-  reset_rx_buffer();
 
   while(1)
   {


### PR DESCRIPTION
Amend UART2_RX_IRQHandler - remove state machine, replace with shorter ISR that only writes to ringbuffer and does no processing.
Move state machine to new, separate packet_assembler() that reads the buffer and assembles packets for processing - keeps the original state machine algorithm.
