### PR TITLE
Fix two bugs in UART packet parsing

### DIFF
--- a/src/ebike_app.c
+++ b/src/ebike_app.c
@@ -1507,7 +1507,7 @@ static void packet_assembler(void)
   {
     if (ui8_received_package_flag == 0) // only when package were previously processed
     {
-      while (((uint8_t)(ui8_rx_ringbuffer_read_index+0x1) != ((uint8_t)ui8_rx_ringbuffer_write_index)))
+      while (((uint8_t)(ui8_rx_ringbuffer_read_index) != ((uint8_t)ui8_rx_ringbuffer_write_index)))
       {
         ui8_byte_received = ui8_rx_ringbuffer[(uint8_t)(ui8_rx_ringbuffer_read_index++)];
         
@@ -1537,6 +1537,7 @@ static void packet_assembler(void)
             ui8_rx_cnt = 0;
             ui8_state_machine = 0;
             ui8_received_package_flag = 1; // signal that we have a full package to be processed
+            return;
           }
           break;
 


### PR DESCRIPTION
IMPORTANT: the analysis below is just a speculation, I have tracked this down while debugging an issue with my SW102 firmware, but I haven't checked these fixes yet, connecting the programmer to my bike is a bit cumbersome. I'd be grateful if someone could verify this.

The first bug is the condition in the while loop. The ring buffer is designed so that the read and write indices are equal if the buffer is empty. This means that the +1 in the loop condition is superfluous and will cause the parser to postpone reading the last received byte.

The second bug is a lack of 'return' when a full packet is received. If subsequent bytes are available in the ringbuffer, they will be processed as a beginning of a new packet, overwriting the one which hasn't yet been processed. This can happen frequently because of the first issue - the last byte of the previous packet will be processed ONLY if more bytes are available.

In effect, received packets frequently corrupt each other. The reason why this works at all, is that the packets are rarely changing, so that the overwritten bytes will most likely have the same values. When two different packets are sent, a CRC error occurs. However, if some value is changing continuously (as was the case with my firmware), all packets get rejected and the motor controller fails with a FATAL_ERROR. 

With my SW102 firmware, I was even able to reproduce this by hammering on the +/- buttons. Your version seems to have more aggressive key debouncing (or some other limiting factor) and I've not been able to trigger the bug there.

As a simple workaround, the display can send one dummy byte after each packet. This has an effect of triggering the parser to consume the whole packet before a new one is received. In my tests, this eliminates the problem entirely.